### PR TITLE
feat: AI SDK devtools support - adapter, live viewer, run scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ npx unbox-ai devtools
 
 Every `generateText` / `streamText` call streams into the viewer live - token
 treemap, cache-hit attribution, latency waterfall, and diffed messages update
-as your agent runs. Each root run gets its own entry in the sidebar run list
-(the viewer follows the newest run until you pin an older one); nested agent
-runs (tools that call the AI SDK again) show up as segments inside their run.
-The static commands work on the database file too:
-`unbox-ai summary .devtools/generations.json`.
+as your agent runs. Every run gets its own entry in the sidebar run list, with
+nested agent runs (tools that call the AI SDK again) indented under their
+parent; the viewer follows the newest run until you pin an older one, and
+concurrent streams stay individually visible. The static commands work on the
+database file too: `unbox-ai summary .devtools/generations.json`.
 
 The run list is not devtools-only - `unbox-ai view a.trace.json b.trace.json`
 opens several trace files (any mix of formats) as one run list.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="#quickstart"><strong>Quickstart</strong></a> |
+  <a href="#ai-sdk-devtools-live"><strong>AI SDK DevTools</strong></a> |
   <a href="#the-viewer"><strong>Viewer</strong></a> |
   <a href="#for-agents"><strong>For Agents</strong></a> |
   <a href="#skill-installation"><strong>Skills</strong></a> |
@@ -50,14 +51,45 @@ npx unbox-ai trace.json
 ```
 
 That's it. A local server starts and your browser opens the viewer. Works with
-gateway exports and opencode session exports (see
+gateway exports, opencode session exports, and AI SDK devtools databases (see
 [Trace Formats](#trace-formats)).
 
 ```
 --json        machine-readable output
---port <n>    server port (default 4177)
+--port <n>    server port (view default 4177, devtools default 4983)
 --no-open     start the server without opening a browser
 ```
+
+## AI SDK DevTools (live)
+
+`unbox-ai devtools` is a drop-in replacement for the
+[`@ai-sdk/devtools`](https://www.npmjs.com/package/@ai-sdk/devtools) viewer:
+same capture setup, this viewer instead. Instrument your app exactly as the
+AI SDK documents it:
+
+```ts
+import { registerTelemetry } from "ai";
+import { DevToolsTelemetry } from "@ai-sdk/devtools";
+
+registerTelemetry(DevToolsTelemetry());
+```
+
+Then, instead of `npx @ai-sdk/devtools`, run:
+
+```bash
+npx unbox-ai devtools
+```
+
+Every `generateText` / `streamText` call streams into the viewer live - token
+treemap, cache-hit attribution, latency waterfall, and diffed messages update
+as your agent runs. Each root run gets its own entry in the sidebar run list
+(the viewer follows the newest run until you pin an older one); nested agent
+runs (tools that call the AI SDK again) show up as segments inside their run.
+The static commands work on the database file too:
+`unbox-ai summary .devtools/generations.json`.
+
+The run list is not devtools-only - `unbox-ai view a.trace.json b.trace.json`
+opens several trace files (any mix of formats) as one run list.
 
 ## The Viewer
 
@@ -76,6 +108,7 @@ per-generation totals) and labeled as such.
 The same binary is a bounded, read-only trace explorer - safe to allowlist:
 
 ```bash
+unbox-ai runs trace.json             # multi-run sources: one line per run, then scope with --run
 unbox-ai summary trace.json          # totals + one line per generation
 unbox-ai events trace.json           # table: tokens, latency, cost, tool calls
 unbox-ai event trace.json 5          # one generation, new messages only
@@ -120,6 +153,12 @@ pointers to fetch full values.
   automatically. Real cache read/write tokens and per-tool execution times
   carry over. Note: opencode exports omit the system prompt and tool
   definitions, so token attribution assigns their weight to the conversation.
+- **AI SDK devtools databases** (`{runs[], steps[]}`,
+  `.devtools/generations.json` written by `@ai-sdk/devtools`) - adapted
+  automatically, and served live by `unbox-ai devtools`. Cache-read tokens
+  carry over; the AI SDK reports no cost or TTFT, so those show as zero/absent.
+  Tool definitions arrive without their JSON schemas, so the treemap's tools
+  group reflects names and descriptions only.
 
 There is no universal AI-trace standard yet; the closest are the OpenTelemetry
 GenAI semantic conventions, OpenInference, and OpenLLMetry (all span-based).

--- a/skills/unbox-ai/SKILL.md
+++ b/skills/unbox-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unbox-ai
-description: Analyze AI agent trace files (*.trace.json - gateway or opencode exports) without reading the raw JSON. Use when asked to inspect an agent run, find why it was slow or expensive, check cache efficiency, debug tool calls, or summarize what an agent did. All commands are read-only with bounded output - safe to run freely.
+description: Analyze AI agent trace files (*.trace.json - gateway or opencode exports, or .devtools/generations.json AI SDK devtools databases, even mid-run while the app writes them) without reading the raw JSON. Use when asked to inspect an agent run, find why it was slow or expensive, check cache efficiency, debug tool calls, or summarize what an agent did. All commands are read-only with bounded output - safe to run freely.
 ---
 
 # unbox-ai: explore AI traces from the CLI
@@ -16,6 +16,7 @@ Run via `npx unbox-ai` (or `node dist/cli/index.js` in the unbox-ai repo).
 Always start wide, then drill:
 
 ```bash
+unbox-ai runs <trace>           # multi-run sources only: one line per independent run
 unbox-ai summary <trace>        # who/what/cost + one line per generation
 unbox-ai tools <trace>          # per-tool usage: calls, failures, time, output size
 unbox-ai events <trace>         # table: tokens, latency, cost per generation
@@ -26,6 +27,10 @@ unbox-ai get <trace> '<path>'   # exact raw value, e.g. events[3].messages[2].co
 
 - `--json` on summary/events/event/tools/messages for machine-readable output
   (unbounded - prefer the plain forms first).
+- `--run <n|id>` scopes any text command to one run of a multi-run source
+  (AI SDK devtools databases hold many). Without it they see the whole file
+  merged. Keep passing the same `--run` when following printed pointers -
+  generation indexes are run-local.
 - Truncated output always prints the exact `get` invocation that returns the
   rest. Follow those pointers instead of guessing paths.
 - `--grep` accepts regex; invalid regex silently falls back to literal search.
@@ -39,6 +44,8 @@ unbox-ai get <trace> '<path>'   # exact raw value, e.g. events[3].messages[2].co
   thread (resets and interleaved agents split threads).
 - `caching NN%` = input tokens that were a repeated, cache-eligible prefix
   (real cache reads when the trace reports them, else inferred from repeats).
+- cost `-` = the source reports no dollar amounts (AI SDK devtools traces);
+  reason about tokens instead.
 - `latency NN% prompt wait` = share of model time spent re-reading input
   (TTFT). High = the run is prompt-bound; shrinking resent context cuts both
   cost and wall-clock.
@@ -71,7 +78,28 @@ Failures: `unbox-ai tools <trace>` failed column, then
 
 ## Supported formats
 
-Gateway exports (`{events[]}` with cumulative message snapshots) and opencode
-session exports (`{info, messages[{info, parts}]}`) are auto-detected -
-`summary` prints which. Unknown files fail with a readable error; do not
-retry with other commands.
+Gateway exports (`{events[]}` with cumulative message snapshots), opencode
+session exports (`{info, messages[{info, parts}]}`), and AI SDK devtools
+databases (`{runs[], steps[]}`, usually `.devtools/generations.json`) are
+auto-detected - `summary` prints which. Unknown files fail with a readable
+error; do not retry with other commands.
+
+## Live AI SDK apps (devtools databases)
+
+A project instrumented with `@ai-sdk/devtools` writes every AI SDK call to
+`.devtools/generations.json` in the app's cwd - analyze it with the commands
+above WHILE the app runs. Each command reads a fresh snapshot, so this is the
+way to debug an agent mid-flight:
+
+```bash
+unbox-ai runs .devtools/generations.json            # what ran / is running ([live])
+unbox-ai summary .devtools/generations.json --run 2 # drill into one run
+unbox-ai tools .devtools/generations.json --run 2   # its tool behavior
+```
+
+- Always start with `runs` on these files and scope with `--run`; the
+  unscoped view merges every run and its indexes shift as the app appends.
+- A run marked `[live]` (or a generation with latency 0.00s and no output)
+  is still executing - re-run the command for updated state.
+- `unbox-ai devtools` serves a live browser viewer of the same file; only
+  offer it to the human, as an agent stay on the read commands.

--- a/src/cli/commands/event.ts
+++ b/src/cli/commands/event.ts
@@ -48,6 +48,13 @@ export function event(loaded: LoadedTrace, index: number, json: boolean): void {
 
 function printMessage(message: Message, genIndex: number): void {
   console.log(`--- [${message.index}] ${message.role} (~${formatTokens(message.approxTokens)} tok)`);
+  if (message.reasoning !== undefined) {
+    console.log(
+      message.reasoning
+        ? `  thinking: ${truncate(message.reasoning.replace(/\s+/g, " "), contentPointer(genIndex, message.index), 200)}`
+        : "  thinking: (content withheld by provider)",
+    );
+  }
   if (message.text) console.log(truncate(message.text, contentPointer(genIndex, message.index)));
   message.toolCalls?.forEach((call, callIndex) => {
     console.log(

--- a/src/cli/commands/messages.ts
+++ b/src/cli/commands/messages.ts
@@ -1,6 +1,6 @@
 import type { Message, MessageRole } from "../../core/types";
 import type { LoadedTrace } from "../load";
-import { contentPointer, formatTokens, printJson, truncate } from "../output";
+import { contentPointer, formatTokens, getTraceRef, printJson, truncate } from "../output";
 
 export interface MessagesFilter {
   role?: MessageRole;
@@ -38,7 +38,7 @@ export function messages(loaded: LoadedTrace, filter: MessagesFilter, json: bool
     const calls = hit.toolCalls?.map((c) => c.name).join(",");
     const body =
       hit.match && hit.match.where !== "text"
-        ? `matched in ${hit.match.where}: "...${hit.match.snippet}..." - drill in: unbox-ai event <trace> ${hit.gen}`
+        ? `matched in ${hit.match.where}: "...${hit.match.snippet}..." - drill in: unbox-ai event ${getTraceRef()} ${hit.gen}`
         : hit.text
           ? truncate(
               hit.text.replace(/\s+/g, " "),
@@ -46,7 +46,7 @@ export function messages(loaded: LoadedTrace, filter: MessagesFilter, json: bool
               240,
               hit.text.length,
             )
-          : `tool_calls: ${calls} - drill in: unbox-ai event <trace> ${hit.gen}`;
+          : `tool_calls: ${calls} - drill in: unbox-ai event ${getTraceRef()} ${hit.gen}`;
     console.log(
       `[gen ${hit.gen} msg ${hit.index}] ${hit.role} (~${formatTokens(hit.approxTokens)} tok): ${body}`,
     );
@@ -62,10 +62,13 @@ interface Match {
   snippet: string;
 }
 
-/** Locates the first pattern match in a message: body text, call args, or a result. */
+/** Locates the first pattern match in a message: body text, reasoning, call args, or a result. */
 function findMatch(m: Message, pattern: RegExp | undefined): Match | null {
   if (!pattern) return { where: "text", snippet: "" };
   if (pattern.test(m.text)) return { where: "text", snippet: "" };
+  if (m.reasoning && pattern.test(m.reasoning)) {
+    return { where: "thinking", snippet: snippet(m.reasoning, pattern) };
+  }
   for (const call of m.toolCalls ?? []) {
     const args = JSON.stringify(call.args);
     if (pattern.test(args)) return { where: `${call.name} args`, snippet: snippet(args, pattern) };

--- a/src/cli/commands/runs.ts
+++ b/src/cli/commands/runs.ts
@@ -21,7 +21,9 @@ export function runs(items: TraceCollectionItem[], json: boolean): void {
         formatTokens(run.totalTokens.input),
         formatTokens(run.totalTokens.output),
         run.timestamp,
-        (run.inProgress ? "[live] " : "") +
+        "  ".repeat(run.depth) +
+          (run.depth > 0 ? "> " : "") +
+          (run.inProgress ? "[live] " : "") +
           (run.name.length > 60 ? `${run.name.slice(0, 60)}...` : run.name),
       ]),
     ),

--- a/src/cli/commands/runs.ts
+++ b/src/cli/commands/runs.ts
@@ -1,0 +1,30 @@
+import { runSummaries, type TraceCollectionItem } from "../../core/collection";
+import { formatTokens, printJson, table } from "../output";
+
+/** One line per independent run; feeds --run selectors on the other commands. */
+export function runs(items: TraceCollectionItem[], json: boolean): void {
+  const summaries = runSummaries(items);
+  if (json) {
+    printJson(summaries.map((run, index) => ({ run: index, ...run })));
+    return;
+  }
+  if (summaries.length === 0) {
+    console.log("no runs yet");
+    return;
+  }
+  console.log(
+    table(
+      ["run", "gens", "in", "out", "started", "name"],
+      summaries.map((run, index) => [
+        String(index),
+        String(run.generations),
+        formatTokens(run.totalTokens.input),
+        formatTokens(run.totalTokens.output),
+        run.timestamp,
+        (run.inProgress ? "[live] " : "") +
+          (run.name.length > 60 ? `${run.name.slice(0, 60)}...` : run.name),
+      ]),
+    ),
+  );
+  console.log("\nscope any command to one run: unbox-ai summary <trace> --run <n>");
+}

--- a/src/cli/commands/summary.ts
+++ b/src/cli/commands/summary.ts
@@ -2,7 +2,7 @@ import { formatPercent } from "../../core/format";
 import { computeInsights } from "../../core/insights";
 import { toolCallNames } from "../../core/normalize";
 import type { LoadedTrace } from "../load";
-import { formatCallNames, formatCost, formatSeconds, formatTokens, printJson } from "../output";
+import { formatCallNames, formatCost, formatSeconds, formatTokens, getTraceRef, printJson } from "../output";
 
 /** Prints trace totals plus a one-liner per generation. */
 export function summary(loaded: LoadedTrace, json: boolean): void {
@@ -59,5 +59,5 @@ export function summary(loaded: LoadedTrace, json: boolean): void {
         `${formatSeconds(gen.metrics.latency)}  ${formatCost(gen.metrics.cost)}  ${doing}`,
     );
   }
-  console.log("\nnext: unbox-ai events <trace> | unbox-ai event <trace> <idx>");
+  console.log(`\nnext: unbox-ai events ${getTraceRef()} | unbox-ai event ${getTraceRef()} <idx>`);
 }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -1,7 +1,7 @@
 import { formatCompact, formatMs } from "../../core/format";
 import { allToolCalls } from "../../core/normalize";
 import type { LoadedTrace } from "../load";
-import { printJson, table, truncate } from "../output";
+import { getTraceRef, printJson, table, truncate } from "../output";
 
 const ARGS_PREVIEW_CHARS = 60;
 
@@ -30,7 +30,7 @@ export function tools(loaded: LoadedTrace, json: boolean, all: boolean): void {
       truncate(JSON.stringify(call.args) ?? "", undefined, ARGS_PREVIEW_CHARS).replace(/\n.*/s, "..."),
     ]);
     console.log(table(["gen", "name", "status", "time", "size", "args"], rows));
-    console.log("\ndrill in: unbox-ai event <trace> <gen>");
+    console.log(`\ndrill in: unbox-ai event ${getTraceRef()} <gen>`);
     return;
   }
 
@@ -56,7 +56,7 @@ export function tools(loaded: LoadedTrace, json: boolean, all: boolean): void {
       formatCompact(u.totalSize),
     ]);
   console.log(table(["tool", "calls", "failed", "time", "output"], rows));
-  console.log(`\n${calls.length} calls across ${byName.size} tools · every call: unbox-ai tools <trace> --all`);
+  console.log(`\n${calls.length} calls across ${byName.size} tools · every call: unbox-ai tools ${getTraceRef()} --all`);
 }
 
 function status(success: boolean | undefined, hasResult: boolean): string {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "node:util";
+import { resolve } from "node:path";
 import type { MessageRole } from "../core/types";
 import { event } from "./commands/event";
 import { events } from "./commands/events";
@@ -6,15 +7,20 @@ import { get } from "./commands/get";
 import { messages } from "./commands/messages";
 import { summary } from "./commands/summary";
 import { tools } from "./commands/tools";
-import { fail, loadTrace } from "./load";
+import { runs } from "./commands/runs";
+import { createLiveSource } from "./live";
+import { fail, loadCollectionFiles, loadRun, loadTrace } from "./load";
 import { openBrowser } from "./open-browser";
-import { startServer } from "./server";
+import { setTraceRef } from "./output";
+import { startServer, staticSource } from "./server";
 
 const HELP = `unbox-ai - visualize and explore AI traces
 
 Usage:
   unbox-ai <trace.json>                  open the visualization (summary when piped)
-  unbox-ai view <trace.json>             open the visualization
+  unbox-ai view <trace.json> [more...]   open the visualization (several files = one run list)
+  unbox-ai devtools                      live viewer for AI SDK apps (@ai-sdk/devtools drop-in)
+  unbox-ai runs <trace.json>             one line per independent run (devtools databases)
   unbox-ai summary <trace.json>          totals + one line per generation
   unbox-ai events <trace.json>           generation table (tokens, latency, cost, tool calls)
   unbox-ai event <trace.json> <idx>      one generation: metrics, token split, new messages
@@ -24,7 +30,8 @@ Usage:
 
 Options:
   --json          machine-readable output, unbounded (summary, events, event, messages)
-  --port <n>      server port for view (default 4177)
+  --run <n|id>    scope a text command to one run of a multi-run source (see: runs)
+  --port <n>      server port (view default 4177; devtools default 4983)
   --no-open       start the server without opening a browser
   --role <r>      filter: system | user | assistant | tool-result | unknown
   --event <n>     filter: only messages of generation n
@@ -35,7 +42,7 @@ Plain output is bounded; truncations include the exact "get" invocation
 that returns the rest. --json is complete and therefore unbounded.
 All commands are read-only - safe for agents to run freely.`;
 
-const COMMANDS = new Set(["view", "summary", "events", "event", "tools", "messages", "get"]);
+const COMMANDS = new Set(["view", "runs", "summary", "events", "event", "tools", "messages", "get"]);
 
 const ROLES: MessageRole[] = ["system", "user", "assistant", "tool-result", "unknown"];
 
@@ -43,7 +50,8 @@ function main(): void {
   const { values, positionals } = parseArgs({
     options: {
       json: { type: "boolean", default: false },
-      port: { type: "string", default: "4177" },
+      run: { type: "string" },
+      port: { type: "string" },
       "no-open": { type: "boolean", default: false },
       all: { type: "boolean", default: false },
       role: { type: "string" },
@@ -66,18 +74,32 @@ function main(): void {
   }
 
   const [first, ...rest] = positionals;
+  if (first === "devtools") {
+    devtools(values).catch((error) =>
+      fail(error instanceof Error ? error.message : String(error)),
+    );
+    return;
+  }
   const command = COMMANDS.has(first!) ? first! : defaultCommand();
-  const [tracePath, arg] = COMMANDS.has(first!) ? rest : [first, ...rest];
+  const paths = COMMANDS.has(first!) ? rest : [first!, ...rest];
+  const [tracePath, arg] = paths;
   if (!tracePath) fail("Missing trace file. See: unbox-ai --help");
 
-  const loaded = loadTrace(tracePath);
+  if (command === "view") {
+    view(paths, values).catch((error) =>
+      fail(error instanceof Error ? error.message : String(error)),
+    );
+    return;
+  }
+  if (command === "runs") {
+    runs(loadCollectionFiles(paths), values.json);
+    return;
+  }
+
+  if (values.run !== undefined) setTraceRef(`<trace> --run ${values.run}`);
+  const loaded = values.run !== undefined ? loadRun(tracePath, values.run) : loadTrace(tracePath);
 
   switch (command) {
-    case "view":
-      view(loaded, values).catch((error) =>
-        fail(error instanceof Error ? error.message : String(error)),
-      );
-      return;
     case "summary":
       summary(loaded, values.json);
       return;
@@ -115,12 +137,53 @@ function defaultCommand(): string {
 }
 
 async function view(
-  loaded: ReturnType<typeof loadTrace>,
-  values: { port: string; "no-open": boolean },
+  paths: string[],
+  values: { port?: string; "no-open": boolean },
 ): Promise<void> {
-  const { port } = await startServer(loaded.trace, loaded.raw, parsePort(values.port));
+  const items = loadCollectionFiles(paths);
+  if (items.length === 0) fail("No runs found in the given files.");
+  const { port } = await startServer(staticSource(items), parsePort(values.port ?? "4177"));
   const url = `http://localhost:${port}`;
-  console.log(`unbox-ai: serving ${loaded.path} at ${url} (ctrl-c to stop)`);
+  const label = paths.length === 1 ? paths[0] : `${paths.length} files`;
+  const runs = items.length > 1 ? ` (${items.length} runs)` : "";
+  console.log(`unbox-ai: serving ${label}${runs} at ${url} (ctrl-c to stop)`);
+  if (!values["no-open"]) openBrowser(url);
+}
+
+/**
+ * Live devtools mode: a drop-in replacement for the @ai-sdk/devtools viewer.
+ * The DevToolsTelemetry integration in the user's app writes
+ * .devtools/generations.json and POSTs /api/notify after every step; this
+ * server re-reads the file on each ping and pushes updates to the viewer.
+ * The port must be exact - the app targets it directly (AI_SDK_DEVTOOLS_PORT).
+ */
+async function devtools(values: { port?: string; "no-open": boolean }): Promise<void> {
+  const dbPath = resolve(process.cwd(), ".devtools/generations.json");
+  const source = createLiveSource(dbPath);
+  const hasData = source.reload();
+  const preferred = parsePort(values.port ?? process.env.AI_SDK_DEVTOOLS_PORT ?? "4983");
+  const { port } = await startServer(source, preferred, { exactPort: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "EADDRINUSE") {
+      fail(
+        `port ${preferred} is in use - is @ai-sdk/devtools or another unbox-ai devtools running?\n` +
+          `Pick another port with --port <n> and set AI_SDK_DEVTOOLS_PORT=<n> in your app.`,
+      );
+    }
+    throw error;
+  });
+  const url = `http://localhost:${port}`;
+  console.log(`unbox-ai: devtools viewer at ${url} (ctrl-c to stop)`);
+  if (hasData) {
+    console.log(`unbox-ai: loaded ${dbPath}`);
+  } else {
+    console.log(`unbox-ai: waiting for AI SDK calls. In your app:
+
+  import { registerTelemetry } from "ai";
+  import { DevToolsTelemetry } from "@ai-sdk/devtools";
+
+  registerTelemetry(DevToolsTelemetry());
+`);
+  }
   if (!values["no-open"]) openBrowser(url);
 }
 

--- a/src/cli/live.ts
+++ b/src/cli/live.ts
@@ -1,0 +1,86 @@
+import { readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { parseCollection } from "../core/collection";
+import { buildCollection, type TraceSource } from "./server";
+
+/** Guards against a synchronous hang / OOM on an enormous database file. */
+const MAX_DB_BYTES = 100 * 1024 * 1024;
+
+/**
+ * A TraceSource backed by an @ai-sdk/devtools database file. Reloads on
+ * every notify ping from the instrumented app; a ping may move the db path
+ * (apps notify from their own cwd), so paths are validated to
+ * .devtools/generations.json files only. Parse failures keep the last good
+ * state - the file is rewritten on every step and can be caught mid-write.
+ */
+export function createLiveSource(defaultDbPath: string): TraceSource & { reload(): boolean } {
+  let dbPath = defaultDbPath;
+  let snapshot = buildCollection([]);
+  const listeners = new Set<() => void>();
+
+  function reload(): boolean {
+    let text: string;
+    try {
+      text = readFileSync(dbPath, "utf8");
+    } catch {
+      return false; // the app has not written anything yet
+    }
+    try {
+      snapshot = buildCollection(parseCollection(JSON.parse(text)).items);
+    } catch {
+      // the app rewrites the file on every step, so a read can catch it
+      // mid-write; keep the last good state - the next ping re-reads
+      return false;
+    }
+    for (const listener of listeners) listener();
+    return true;
+  }
+
+  return {
+    live: true,
+    current: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    notify(remoteDbPath) {
+      if (remoteDbPath !== undefined) {
+        const validated = validateDbPath(remoteDbPath);
+        if (validated === undefined) return false;
+        dbPath = validated;
+      }
+      reload();
+      return true;
+    },
+    clear() {
+      try {
+        // empty the file itself (matches @ai-sdk/devtools) so the clear
+        // survives app restarts; a running app's in-memory cache may still
+        // resurrect old runs on its next write
+        writeFileSync(dbPath, JSON.stringify({ runs: [], steps: [] }, null, 2));
+      } catch {
+        // nothing written yet - clearing the snapshot is enough
+      }
+      snapshot = buildCollection([]);
+      for (const listener of listeners) listener();
+    },
+    reload,
+  };
+}
+
+/** Only real .devtools/generations.json files are accepted from notify payloads. */
+function validateDbPath(path: unknown): string | undefined {
+  if (typeof path !== "string") return undefined;
+  const isDbFile = (p: string) =>
+    basename(p) === "generations.json" && basename(dirname(p)) === ".devtools";
+  const resolved = resolve(path);
+  if (!isDbFile(resolved)) return undefined;
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile() || stats.size > MAX_DB_BYTES) return undefined;
+    const real = realpathSync(resolved);
+    return isDbFile(real) ? real : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/cli/live.ts
+++ b/src/cli/live.ts
@@ -1,5 +1,5 @@
 import { readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
+import { basename, dirname, resolve, sep } from "node:path";
 import { parseCollection } from "../core/collection";
 import { buildCollection, type TraceSource } from "./server";
 
@@ -68,7 +68,12 @@ export function createLiveSource(defaultDbPath: string): TraceSource & { reload(
   };
 }
 
-/** Only real .devtools/generations.json files are accepted from notify payloads. */
+/**
+ * Only real .devtools/generations.json files under the viewer's cwd are
+ * accepted from notify payloads - start `unbox-ai devtools` at the workspace
+ * root when apps live deeper. Anything else could point the viewer at
+ * another project's captured prompts.
+ */
 function validateDbPath(path: unknown): string | undefined {
   if (typeof path !== "string") return undefined;
   const isDbFile = (p: string) =>
@@ -79,6 +84,8 @@ function validateDbPath(path: unknown): string | undefined {
     const stats = statSync(resolved);
     if (!stats.isFile() || stats.size > MAX_DB_BYTES) return undefined;
     const real = realpathSync(resolved);
+    const root = realpathSync(process.cwd());
+    if (real !== root && !real.startsWith(root + sep)) return undefined;
     return isDbFile(real) ? real : undefined;
   } catch {
     return undefined;

--- a/src/cli/load.ts
+++ b/src/cli/load.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolveAdapter } from "../core/adapters";
+import { parseCollection, type TraceCollectionItem } from "../core/collection";
 import { normalizeTrace } from "../core/normalize";
 import type { NormalizedTrace, RawTrace } from "../core/types";
 
@@ -13,26 +14,59 @@ export interface LoadedTrace {
 
 /** Reads, parses, and normalizes a trace file, exiting with a readable error on failure. */
 export function loadTrace(path: string): LoadedTrace {
+  const json = readJson(path);
+  try {
+    // adapters (e.g. opencode) synthesize the internal raw shape; `get`
+    // pointers resolve against that adapted form. Multi-run sources are
+    // merged here - the text commands speak one trace
+    const adapter = resolveAdapter(json);
+    const raw = adapter.adapt(json);
+    return { path, format: adapter.name, raw, trace: normalizeTrace(raw) };
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Loads one trace per independent run across the given files - a devtools
+ * database splits per root run, and several files concatenate.
+ */
+export function loadCollectionFiles(paths: string[]): TraceCollectionItem[] {
+  try {
+    return paths.flatMap((path) => parseCollection(readJson(path)).items);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Loads one run of a multi-run source, selected by `runs` index or trace id. */
+export function loadRun(path: string, selector: string): LoadedTrace {
+  const json = readJson(path);
+  try {
+    const { format, items } = parseCollection(json);
+    const item = /^\d+$/.test(selector)
+      ? items[Number(selector)]
+      : items.find(({ trace }) => trace.traceId === selector);
+    if (!item) {
+      throw new Error(`No run "${selector}" (${items.length} runs). List them: unbox-ai runs ${path}`);
+    }
+    return { path, format, raw: item.raw, trace: item.trace };
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function readJson(path: string): unknown {
   let text: string;
   try {
     text = readFileSync(path, "utf8");
   } catch {
     fail(`Cannot read file: ${path}`);
   }
-  let json: unknown;
   try {
-    json = JSON.parse(text);
+    return JSON.parse(text);
   } catch {
     fail(`Not valid JSON: ${path}`);
-  }
-  try {
-    // adapters (e.g. opencode) synthesize the internal raw shape; `get`
-    // pointers resolve against that adapted form
-    const adapter = resolveAdapter(json);
-    const raw = adapter.adapt(json);
-    return { path, format: adapter.name, raw, trace: normalizeTrace(raw) };
-  } catch (error) {
-    fail(error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,5 +1,17 @@
 export { formatCallNames, formatCost, formatSeconds, formatTokens } from "../core/format";
 
+let traceRef = "<trace>";
+
+/** Set once when --run scopes the process, so printed hints stay copy-pasteable. */
+export function setTraceRef(ref: string): void {
+  traceRef = ref;
+}
+
+/** How printed hints refer to the trace argument, e.g. "<trace> --run 2". */
+export function getTraceRef(): string {
+  return traceRef;
+}
+
 /** Canonical `get` pointer to a message's content. */
 export function contentPointer(genIndex: number, messageIndex: number): string {
   return `events[${genIndex}].messages[${messageIndex}].content`;
@@ -26,7 +38,7 @@ export function truncate(
 ): string {
   if (text.length <= max) return text;
   const rest = Math.max(sourceLength - max, 1);
-  const hint = pointer ? ` - run: unbox-ai get <trace> '${pointer}'` : "";
+  const hint = pointer ? ` - run: unbox-ai get ${traceRef} '${pointer}'` : "";
   return `${text.slice(0, max)}\n[... ${rest} more chars${hint}]`;
 }
 

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -78,8 +78,29 @@ export async function startServer(
 ): Promise<{ servers: Server[]; port: number }> {
   const dir = viewerDir();
 
+  // set once listen() resolves; requests only arrive after that
+  let boundPort = preferredPort;
+  const allowedHosts = () =>
+    new Set([`localhost:${boundPort}`, `127.0.0.1:${boundPort}`, `[::1]:${boundPort}`]);
+
   const handler = async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url ?? "/", "http://localhost");
+    // DNS-rebinding and cross-site protection for everything under /api:
+    // the Host must be this server's own, and browser requests (Origin set)
+    // must come from a page this server itself served
+    if (url.pathname.startsWith("/api/")) {
+      const { host, origin } = req.headers;
+      const originHost = typeof origin === "string" ? origin.replace(/^https?:\/\//, "") : undefined;
+      if (
+        host === undefined ||
+        !allowedHosts().has(host) ||
+        (originHost !== undefined && !allowedHosts().has(originHost))
+      ) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden" }));
+        return;
+      }
+    }
     if (url.pathname === "/api/traces") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(source.current().listJson);
@@ -149,7 +170,9 @@ export async function startServer(
   };
 
   const hosts = source.live ? ["127.0.0.1", "::1"] : ["127.0.0.1"];
-  return listen(handler, hosts, preferredPort, options.exactPort ? 1 : 10);
+  const bound = await listen(handler, hosts, preferredPort, options.exactPort ? 1 : 10);
+  boundPort = bound.port;
+  return bound;
 }
 
 /**
@@ -185,6 +208,8 @@ async function serveNotify(
   try {
     dbPath = (JSON.parse(await readBody(req)) as { dbPath?: unknown }).dbPath;
   } catch {
+    // an oversized body drops the connection; nothing left to respond to
+    if (req.destroyed) return;
     // a malformed body still triggers a reload of the current db path
   }
   const accepted = source.notify!(dbPath);
@@ -197,7 +222,10 @@ function readBody(req: IncomingMessage, limit = 64 * 1024): Promise<string> {
     let body = "";
     req.on("data", (chunk: Buffer) => {
       body += chunk.toString("utf8");
-      if (body.length > limit) reject(new Error("body too large"));
+      if (body.length > limit) {
+        reject(new Error("body too large"));
+        req.destroy();
+      }
     });
     req.on("end", () => resolve(body));
     req.on("error", reject);

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -1,9 +1,9 @@
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { extname, join, normalize, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { runSummaries, type TraceCollectionItem } from "../core/collection";
 import { resolvePath } from "../core/path";
-import type { NormalizedTrace, RawTrace } from "../core/types";
 
 const MIME: Record<string, string> = {
   ".html": "text/html",
@@ -15,6 +15,50 @@ const MIME: Record<string, string> = {
   ".json": "application/json",
 };
 
+/** One servable trace with its response body pre-stringified. */
+export interface ServedTrace extends TraceCollectionItem {
+  traceJson: string;
+}
+
+export interface Collection {
+  items: ServedTrace[];
+  /** /api/traces body: one RunSummary per item. */
+  listJson: string;
+}
+
+/** What the server serves: a static snapshot or a live, mutable collection. */
+export interface TraceSource {
+  /** True when traces can change while the server runs (devtools mode). */
+  live: boolean;
+  current(): Collection;
+  /** Live sources push one event per collection change. Returns an unsubscribe. */
+  subscribe?(listener: () => void): () => void;
+  /** Live sources ingest a notify ping; false rejects the payload. */
+  notify?(dbPath: unknown): boolean;
+  /** Live sources empty the backing database. */
+  clear?(): void;
+}
+
+export function buildCollection(items: TraceCollectionItem[]): Collection {
+  return {
+    items: items.map((item) => ({ ...item, traceJson: JSON.stringify(item.trace) })),
+    listJson: JSON.stringify(runSummaries(items)),
+  };
+}
+
+/** Wraps immutable loaded traces in the TraceSource shape. */
+export function staticSource(items: TraceCollectionItem[]): TraceSource {
+  const snapshot = buildCollection(items);
+  return { live: false, current: () => snapshot };
+}
+
+/** The trace an api request addresses: ?id=<traceId>, defaulting to the newest. */
+function pickTrace(collection: Collection, url: URL): ServedTrace | undefined {
+  const id = url.searchParams.get("id");
+  if (id !== null) return collection.items.find((item) => item.trace.traceId === id);
+  return collection.items.at(-1);
+}
+
 /** Directory of built viewer assets, shipped next to the bundled CLI. */
 function viewerDir(): string {
   return fileURLToPath(new URL("../viewer", import.meta.url));
@@ -22,27 +66,50 @@ function viewerDir(): string {
 
 /**
  * Serves the built viewer plus the normalized trace at /api/trace,
- * retrying on the next port when the requested one is taken.
+ * retrying on the next port when the requested one is taken. Live sources
+ * additionally get /api/notify (ingest) and update pushes on /api/events,
+ * and bind both loopback stacks - the instrumented app notifies
+ * "localhost", which resolves to ::1 on some machines.
  */
 export async function startServer(
-  trace: NormalizedTrace,
-  raw: RawTrace,
+  source: TraceSource,
   preferredPort: number,
-): Promise<{ server: Server; port: number }> {
-  const traceJson = JSON.stringify(trace);
+  options: { exactPort?: boolean } = {},
+): Promise<{ servers: Server[]; port: number }> {
   const dir = viewerDir();
 
-  const server = createServer(async (req, res) => {
+  const handler = async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url ?? "/", "http://localhost");
-    if (url.pathname === "/api/trace") {
+    if (url.pathname === "/api/traces") {
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(traceJson);
+      res.end(source.current().listJson);
+      return;
+    }
+    if (url.pathname === "/api/trace") {
+      const item = pickTrace(source.current(), url);
+      res.writeHead(item ? 200 : 404, { "content-type": "application/json" });
+      res.end(item?.traceJson ?? JSON.stringify({ error: "no traces yet" }));
       return;
     }
     if (url.pathname === "/api/raw") {
-      const value = resolvePath(raw, url.searchParams.get("path") ?? "");
+      const item = pickTrace(source.current(), url);
+      const value = item && resolvePath(item.raw, url.searchParams.get("path") ?? "");
       res.writeHead(value === undefined ? 404 : 200, { "content-type": "application/json" });
       res.end(JSON.stringify(value === undefined ? { error: "nothing at path" } : { value }));
+      return;
+    }
+    if (url.pathname === "/api/events") {
+      serveEvents(req, res, source);
+      return;
+    }
+    if (url.pathname === "/api/notify" && req.method === "POST" && source.notify) {
+      await serveNotify(req, res, source);
+      return;
+    }
+    if (url.pathname === "/api/clear" && req.method === "POST" && source.clear) {
+      source.clear();
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ success: true }));
       return;
     }
     // unknown api routes must never fall through to the SPA's html
@@ -79,28 +146,105 @@ export async function startServer(
         res.writeHead(404).end("unbox-ai: not found");
       }
     }
-  });
+  };
 
-  const port = await listen(server, preferredPort);
-  return { server, port };
+  const hosts = source.live ? ["127.0.0.1", "::1"] : ["127.0.0.1"];
+  return listen(handler, hosts, preferredPort, options.exactPort ? 1 : 10);
 }
 
-async function listen(server: Server, preferredPort: number): Promise<number> {
-  const MAX_ATTEMPTS = 10;
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+/**
+ * Server-sent events: a hello frame announcing the mode, then one update
+ * frame per trace change. The viewer refetches /api/trace on each update.
+ */
+function serveEvents(req: IncomingMessage, res: ServerResponse, source: TraceSource): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+  });
+  // a push can race the disconnect; writing to a destroyed socket must not throw
+  res.on("error", () => {});
+  const send = (frame: string) => {
+    if (!res.destroyed) res.write(frame);
+  };
+  send(`event: hello\ndata: ${JSON.stringify({ live: source.live })}\n\n`);
+  const unsubscribe = source.subscribe?.(() => send("event: update\ndata: {}\n\n"));
+  const heartbeat = setInterval(() => send(": ping\n\n"), 30_000);
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    unsubscribe?.();
+  });
+}
+
+/** Ingests @ai-sdk/devtools pings: {event, timestamp, dbPath}. */
+async function serveNotify(
+  req: IncomingMessage,
+  res: ServerResponse,
+  source: TraceSource,
+): Promise<void> {
+  let dbPath: unknown;
+  try {
+    dbPath = (JSON.parse(await readBody(req)) as { dbPath?: unknown }).dbPath;
+  } catch {
+    // a malformed body still triggers a reload of the current db path
+  }
+  const accepted = source.notify!(dbPath);
+  res.writeHead(accepted ? 200 : 400, { "content-type": "application/json" });
+  res.end(JSON.stringify(accepted ? { success: true } : { error: "invalid dbPath" }));
+}
+
+function readBody(req: IncomingMessage, limit = 64 * 1024): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString("utf8");
+      if (body.length > limit) reject(new Error("body too large"));
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+type Handler = (req: IncomingMessage, res: ServerResponse) => void;
+
+/**
+ * Binds one server per host on the same port, retrying the whole set on the
+ * next port when any host is taken - a partially bound port would let
+ * another process shadow the other stack. Hosts a machine does not have
+ * (no IPv6 loopback) are skipped.
+ */
+async function listen(
+  handler: Handler,
+  hosts: string[],
+  preferredPort: number,
+  maxAttempts: number,
+): Promise<{ servers: Server[]; port: number }> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const port = preferredPort + attempt;
+    const servers: Server[] = [];
     try {
-      await tryListen(server, port);
-      return port;
+      for (const host of hosts) {
+        const server = createServer(handler);
+        try {
+          await tryListen(server, port, host);
+          servers.push(server);
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          if (code === "EADDRNOTAVAIL" || code === "EAFNOSUPPORT") continue;
+          throw error;
+        }
+      }
+      if (servers.length === 0) throw new Error(`no loopback host available for port ${port}`);
+      return { servers, port };
     } catch (error) {
+      for (const server of servers) server.close();
       const busy = (error as NodeJS.ErrnoException).code === "EADDRINUSE";
-      if (!busy || attempt === MAX_ATTEMPTS - 1) throw error;
+      if (!busy || attempt === maxAttempts - 1) throw error;
     }
   }
   throw new Error("unreachable");
 }
 
-function tryListen(server: Server, port: number): Promise<void> {
+function tryListen(server: Server, port: number, host: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const onError = (error: Error) => {
       server.off("listening", onListening);
@@ -112,6 +256,6 @@ function tryListen(server: Server, port: number): Promise<void> {
     };
     server.once("error", onError);
     server.once("listening", onListening);
-    server.listen(port, "127.0.0.1");
+    server.listen(port, host);
   });
 }

--- a/src/core/adapters/adapter.ts
+++ b/src/core/adapters/adapter.ts
@@ -15,4 +15,10 @@ export interface TraceAdapter<T = unknown> {
   name: string;
   detect(json: unknown): json is T;
   adapt(json: T): RawTrace;
+  /**
+   * Splits a source that holds several independent traces (e.g. one per
+   * devtools run) into parts, each fed to adapt(). Absent for single-trace
+   * formats. May return zero parts when the source is empty.
+   */
+  split?(json: T): T[];
 }

--- a/src/core/adapters/ai-sdk-devtools.ts
+++ b/src/core/adapters/ai-sdk-devtools.ts
@@ -1,0 +1,300 @@
+import { contentToText } from "../normalize";
+import type { RawEvent, RawMessage, RawToolCall, RawToolDef, RawTrace } from "../types";
+import type { TraceAdapter } from "./adapter";
+
+/**
+ * Adapter for AI SDK devtools databases ({runs[], steps[]}, written by
+ * @ai-sdk/devtools to .devtools/generations.json). Each step's input.prompt
+ * is already a cumulative snapshot of the conversation; appending the step's
+ * own response messages yields the exact shape the pipeline speaks - the
+ * next step's prompt repeats prompt + response verbatim, so segment
+ * continuation and tool pairing work unchanged.
+ *
+ * A database holds many independent runs; split() turns each root run (with
+ * its nested child runs) into its own trace. adapt() on the whole database
+ * still yields one merged trace for the text commands.
+ */
+export const aiSdkDevtoolsAdapter: TraceAdapter<DevtoolsDb> = {
+  name: "ai-sdk-devtools",
+  detect: isDevtoolsDb,
+  adapt: adaptDevtoolsDb,
+  split: splitDevtoolsDb,
+};
+
+interface DevtoolsDb {
+  runs: DevtoolsRun[];
+  steps: DevtoolsStep[];
+}
+
+interface DevtoolsRun {
+  id: string;
+  started_at?: string;
+  parent_run_id?: string | null;
+  function_id?: string | null;
+}
+
+interface DevtoolsStep {
+  run_id: string;
+  step_number: number;
+  model_id?: string;
+  provider?: string | null;
+  started_at?: string;
+  duration_ms?: number | null;
+  input: string;
+  output?: string | null;
+  usage?: string | null;
+  error?: string | null;
+}
+
+interface DevtoolsMessage {
+  role: string;
+  content: unknown;
+}
+
+interface DevtoolsPart {
+  type?: string;
+  text?: string;
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+  output?: unknown;
+}
+
+interface DevtoolsInput {
+  prompt?: DevtoolsMessage[];
+  tools?: { name?: string; description?: string; parameters?: unknown }[];
+}
+
+interface DevtoolsOutput {
+  content?: DevtoolsPart[];
+  textParts?: { text?: string }[];
+  reasoningParts?: { text?: string }[];
+  toolCalls?: DevtoolsPart[];
+  response?: { messages?: DevtoolsMessage[] };
+}
+
+interface DevtoolsUsage {
+  inputTokens?: number | { total?: number; cacheRead?: number };
+  outputTokens?: number | { total?: number; reasoning?: number };
+  inputTokenDetails?: { cacheReadTokens?: number };
+  outputTokenDetails?: { reasoningTokens?: number };
+  cachedInputTokens?: number;
+}
+
+function isDevtoolsDb(raw: unknown): raw is DevtoolsDb {
+  const t = raw as Partial<DevtoolsDb>;
+  return (
+    typeof t === "object" &&
+    t !== null &&
+    Array.isArray(t.runs) &&
+    Array.isArray(t.steps) &&
+    t.runs.every((r) => typeof r?.id === "string") &&
+    t.steps.every((s) => typeof s?.run_id === "string" && typeof s?.input === "string")
+  );
+}
+
+/** One part per root run, each carrying the root's nested child runs. */
+function splitDevtoolsDb(db: DevtoolsDb): DevtoolsDb[] {
+  const known = new Set(db.runs.map((run) => run.id));
+  // a run whose parent is not in the file cannot nest anywhere - treat as root
+  const roots = db.runs.filter((run) => !run.parent_run_id || !known.has(run.parent_run_id));
+  const children = new Map<string, DevtoolsRun[]>();
+  for (const run of db.runs) {
+    if (run.parent_run_id && known.has(run.parent_run_id)) {
+      const siblings = children.get(run.parent_run_id) ?? [];
+      siblings.push(run);
+      children.set(run.parent_run_id, siblings);
+    }
+  }
+  return roots.map((root) => {
+    const runs = [root];
+    for (const run of runs) runs.push(...(children.get(run.id) ?? []));
+    const ids = new Set(runs.map((run) => run.id));
+    return { runs, steps: db.steps.filter((step) => ids.has(step.run_id)) };
+  });
+}
+
+function adaptDevtoolsDb(db: DevtoolsDb): RawTrace {
+  const runs = new Map(db.runs.map((run) => [run.id, run]));
+  // file order is append order (steps are written at step start), i.e.
+  // chronological even when parent and child runs interleave
+  const events = db.steps.map((step) => stepEvent(step, runs.get(step.run_id)));
+  const started = [...runs.values()]
+    .map((run) => run.started_at)
+    .filter((t): t is string => typeof t === "string")
+    .sort()[0];
+  return {
+    trace_id: db.runs[0]?.id ?? "ai-sdk-devtools",
+    timestamp: started ?? db.steps[0]?.started_at ?? new Date(0).toISOString(),
+    name: traceName(db),
+    total_tokens: {
+      input: events.reduce((acc, e) => acc + e.metrics.tokens.input, 0),
+      output: events.reduce((acc, e) => acc + e.metrics.tokens.output, 0),
+    },
+    total_cost: 0,
+    ...(events.some((e) => e.in_progress) ? { in_progress: true } : {}),
+    events,
+  };
+}
+
+/** A split part is one run - label it by its ask; a merged db keeps the generic name. */
+function traceName(db: DevtoolsDb): string {
+  const known = new Set(db.runs.map((run) => run.id));
+  const roots = db.runs.filter((run) => !run.parent_run_id || !known.has(run.parent_run_id));
+  const root = roots.length === 1 ? roots[0]! : undefined;
+  if (!root) return "AI SDK devtools session";
+  if (root.function_id) return root.function_id;
+  const firstStep = db.steps.find((step) => step.run_id === root.id);
+  const prompt = parseJson<DevtoolsInput>(firstStep?.input)?.prompt;
+  const ask = prompt?.filter((message) => message.role === "user").at(-1);
+  const text = ask ? contentToText(ask.content).replace(/\s+/g, " ").trim() : "";
+  if (!text) return `run ${root.id.slice(-8)}`;
+  return text.length > 80 ? `${text.slice(0, 80)}...` : text;
+}
+
+function stepEvent(step: DevtoolsStep, run: DevtoolsRun | undefined): RawEvent {
+  const input = parseJson<DevtoolsInput>(step.input);
+  const output = parseJson<DevtoolsOutput>(step.output);
+  const response = responseMessages(output);
+  const messages = [
+    ...(input?.prompt ?? []).flatMap(convertMessage),
+    ...response.flatMap(convertMessage),
+    ...(step.error && response.length === 0
+      ? [{ role: "assistant", content: `[error] ${step.error}` }]
+      : []),
+  ];
+  return {
+    type: "generation",
+    name: run?.function_id ?? (run?.parent_run_id ? "nested run" : "ai-sdk"),
+    model: step.model_id ?? "unknown",
+    provider: step.provider ?? "unknown",
+    ...(step.duration_ms == null && !step.error && !step.output ? { in_progress: true } : {}),
+    metrics: {
+      latency: (step.duration_ms ?? 0) / 1000,
+      tokens: tokensFrom(parseJson<DevtoolsUsage>(step.usage)),
+      // the AI SDK reports token usage, not dollars
+      cost: 0,
+    },
+    ...(input?.tools?.length
+      ? {
+          available_tools: input.tools.map(
+            (tool): RawToolDef => ({
+              type: "function",
+              name: tool.name ?? "unknown",
+              ...(tool.description !== undefined ? { description: tool.description } : {}),
+              ...(tool.parameters !== undefined ? { inputSchema: tool.parameters } : {}),
+            }),
+          ),
+        }
+      : {}),
+    messages,
+  };
+}
+
+/**
+ * The step's own response messages. The telemetry integration writes them
+ * verbatim (output.response.messages, including the step's tool results);
+ * middleware-written steps only have collected parts to reconstruct from.
+ */
+function responseMessages(output: DevtoolsOutput | undefined): DevtoolsMessage[] {
+  if (!output) return [];
+  if (Array.isArray(output.response?.messages)) return output.response.messages;
+  const parts: DevtoolsPart[] = [
+    ...(output.reasoningParts ?? []).map((p) => ({ type: "reasoning", text: p.text })),
+    ...(output.textParts ?? []).map((p) => ({ type: "text", text: p.text })),
+    ...(output.toolCalls ?? []),
+  ];
+  if (parts.length === 0 && Array.isArray(output.content)) {
+    parts.push(...output.content.filter((p) => p?.type !== "tool-result"));
+  }
+  return parts.length ? [{ role: "assistant", content: parts }] : [];
+}
+
+/** Splits tool messages into one result per part; extracts assistant tool calls. */
+function convertMessage(message: DevtoolsMessage): RawMessage[] {
+  if (message.role === "tool" && Array.isArray(message.content)) {
+    return (message.content as DevtoolsPart[])
+      .filter((part) => part?.type === "tool-result")
+      .map(toolResultMessage);
+  }
+  if (message.role === "assistant" && Array.isArray(message.content)) {
+    const parts = message.content as DevtoolsPart[];
+    const calls = parts.filter((part) => part?.type === "tool-call");
+    return [
+      {
+        role: "assistant",
+        content: parts.filter((part) => part?.type !== "tool-call"),
+        ...(calls.length ? { tool_calls: calls.map(toolCall) } : {}),
+      },
+    ];
+  }
+  return [{ role: message.role, content: message.content }];
+}
+
+function toolCall(part: DevtoolsPart, index: number): RawToolCall {
+  return {
+    type: "function",
+    id: part.toolCallId ?? `call_${index}`,
+    function: { name: part.toolName ?? "unknown", arguments: parseArgs(part.input) },
+  };
+}
+
+/** Middleware-written steps store tool args as JSON strings; telemetry stores objects. */
+function parseArgs(input: unknown): unknown {
+  if (typeof input !== "string") return input;
+  try {
+    return JSON.parse(input);
+  } catch {
+    return input;
+  }
+}
+
+function toolResultMessage(part: DevtoolsPart): RawMessage {
+  const output = part.output as { type?: unknown; value?: unknown } | undefined;
+  const wrapped =
+    output !== null && typeof output === "object" && "value" in output && "type" in output;
+  return {
+    role: "tool",
+    content: wrapped ? output.value : part.output,
+    tool_call_id: part.toolCallId,
+    ...(wrapped && typeof output.type === "string" && output.type.startsWith("error")
+      ? { success: false }
+      : {}),
+  };
+}
+
+/**
+ * Handles every usage shape @ai-sdk/devtools has written: current
+ * ({inputTokens: n, inputTokenDetails}), provider-level V4 breakdown
+ * objects, and legacy {inputTokens, cachedInputTokens}. Totals include
+ * cache reads already.
+ */
+function tokensFrom(usage: DevtoolsUsage | undefined): RawEvent["metrics"]["tokens"] {
+  const cacheRead =
+    usage?.inputTokenDetails?.cacheReadTokens ??
+    (typeof usage?.inputTokens === "object" ? usage.inputTokens?.cacheRead : undefined) ??
+    usage?.cachedInputTokens;
+  const reasoning =
+    usage?.outputTokenDetails?.reasoningTokens ??
+    (typeof usage?.outputTokens === "object" ? usage.outputTokens?.reasoning : undefined);
+  return {
+    input: numberOrTotal(usage?.inputTokens),
+    output: numberOrTotal(usage?.outputTokens),
+    ...(typeof cacheRead === "number" ? { cache_read: cacheRead } : {}),
+    ...(typeof reasoning === "number" && reasoning > 0 ? { reasoning } : {}),
+  };
+}
+
+function numberOrTotal(value: number | { total?: number } | undefined): number {
+  if (typeof value === "number") return value;
+  return typeof value?.total === "number" ? value.total : 0;
+}
+
+function parseJson<T>(text: string | null | undefined): T | undefined {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/core/adapters/ai-sdk-devtools.ts
+++ b/src/core/adapters/ai-sdk-devtools.ts
@@ -10,9 +10,13 @@ import type { TraceAdapter } from "./adapter";
  * next step's prompt repeats prompt + response verbatim, so segment
  * continuation and tool pairing work unchanged.
  *
- * A database holds many independent runs; split() turns each root run (with
- * its nested child runs) into its own trace. adapt() on the whole database
- * still yields one merged trace for the text commands.
+ * A database holds many independent runs; split() turns every run - root or
+ * nested child - into its own trace, children ordered right after their
+ * parent. Children stay separate rather than bundled because the telemetry
+ * integration can mis-attribute a concurrent sibling as a child (its
+ * current-tool tracking is a process-wide singleton) - bundling would make
+ * such a run invisible. adapt() on the whole database still yields one
+ * merged trace for the text commands.
  */
 export const aiSdkDevtoolsAdapter: TraceAdapter<DevtoolsDb> = {
   name: "ai-sdk-devtools",
@@ -93,7 +97,7 @@ function isDevtoolsDb(raw: unknown): raw is DevtoolsDb {
   );
 }
 
-/** One part per root run, each carrying the root's nested child runs. */
+/** One part per run, depth-first so children list right after their parent. */
 function splitDevtoolsDb(db: DevtoolsDb): DevtoolsDb[] {
   const known = new Set(db.runs.map((run) => run.id));
   // a run whose parent is not in the file cannot nest anywhere - treat as root
@@ -106,12 +110,16 @@ function splitDevtoolsDb(db: DevtoolsDb): DevtoolsDb[] {
       children.set(run.parent_run_id, siblings);
     }
   }
-  return roots.map((root) => {
-    const runs = [root];
-    for (const run of runs) runs.push(...(children.get(run.id) ?? []));
-    const ids = new Set(runs.map((run) => run.id));
-    return { runs, steps: db.steps.filter((step) => ids.has(step.run_id)) };
-  });
+  const ordered: DevtoolsRun[] = [];
+  const visit = (run: DevtoolsRun) => {
+    ordered.push(run);
+    for (const child of children.get(run.id) ?? []) visit(child);
+  };
+  roots.forEach(visit);
+  return ordered.map((run) => ({
+    runs: [run],
+    steps: db.steps.filter((step) => step.run_id === run.id),
+  }));
 }
 
 function adaptDevtoolsDb(db: DevtoolsDb): RawTrace {
@@ -133,6 +141,9 @@ function adaptDevtoolsDb(db: DevtoolsDb): RawTrace {
     },
     total_cost: 0,
     ...(events.some((e) => e.in_progress) ? { in_progress: true } : {}),
+    ...(db.runs.length === 1 && db.runs[0]!.parent_run_id
+      ? { parent_trace_id: db.runs[0]!.parent_run_id }
+      : {}),
     events,
   };
 }

--- a/src/core/adapters/index.ts
+++ b/src/core/adapters/index.ts
@@ -1,5 +1,6 @@
 import type { RawTrace } from "../types";
 import type { TraceAdapter } from "./adapter";
+import { aiSdkDevtoolsAdapter } from "./ai-sdk-devtools";
 import { gatewayAdapter } from "./gateway";
 import { opencodeAdapter } from "./opencode";
 
@@ -8,6 +9,7 @@ export type { TraceAdapter } from "./adapter";
 /** Most specific detection first; gateway last - it is the internal shape itself. */
 export const ADAPTERS: TraceAdapter[] = [
   opencodeAdapter as TraceAdapter,
+  aiSdkDevtoolsAdapter as TraceAdapter,
   gatewayAdapter as TraceAdapter,
 ];
 

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -1,0 +1,53 @@
+import { resolveAdapter } from "./adapters";
+import { normalizeTrace } from "./normalize";
+import type { NormalizedTrace, RawTrace } from "./types";
+
+export interface TraceCollectionItem {
+  raw: RawTrace;
+  trace: NormalizedTrace;
+}
+
+export interface TraceCollection {
+  /** Which adapter recognized the source, e.g. "ai-sdk-devtools". */
+  format: string;
+  items: TraceCollectionItem[];
+}
+
+/** What the run list shows per trace; served at /api/traces. */
+export interface RunSummary {
+  id: string;
+  name: string;
+  timestamp: string;
+  generations: number;
+  totalTokens: { input: number; output: number };
+  models: string[];
+  inProgress?: boolean;
+}
+
+/**
+ * Parses a source JSON into one trace per independent run. Formats without
+ * a split() are a single-item collection.
+ */
+export function parseCollection(json: unknown): TraceCollection {
+  const adapter = resolveAdapter(json);
+  const parts = adapter.split?.(json) ?? [json];
+  return {
+    format: adapter.name,
+    items: parts.map((part) => {
+      const raw = adapter.adapt(part);
+      return { raw, trace: normalizeTrace(raw) };
+    }),
+  };
+}
+
+export function runSummaries(items: TraceCollectionItem[]): RunSummary[] {
+  return items.map(({ trace }) => ({
+    id: trace.traceId,
+    name: trace.name,
+    timestamp: trace.timestamp,
+    generations: trace.generations.length,
+    totalTokens: trace.totalTokens,
+    models: trace.models,
+    ...(trace.inProgress ? { inProgress: true } : {}),
+  }));
+}

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -22,6 +22,8 @@ export interface RunSummary {
   totalTokens: { input: number; output: number };
   models: string[];
   inProgress?: boolean;
+  /** Nesting level under the spawning run; 0 for roots. */
+  depth: number;
 }
 
 /**
@@ -41,6 +43,7 @@ export function parseCollection(json: unknown): TraceCollection {
 }
 
 export function runSummaries(items: TraceCollectionItem[]): RunSummary[] {
+  const parents = new Map(items.map(({ trace }) => [trace.traceId, trace.parentTraceId]));
   return items.map(({ trace }) => ({
     id: trace.traceId,
     name: trace.name,
@@ -49,5 +52,18 @@ export function runSummaries(items: TraceCollectionItem[]): RunSummary[] {
     totalTokens: trace.totalTokens,
     models: trace.models,
     ...(trace.inProgress ? { inProgress: true } : {}),
+    depth: depthOf(trace.traceId, parents),
   }));
+}
+
+/** Ancestors counted only while present in the collection; cycle-guarded. */
+function depthOf(id: string, parents: Map<string, string | undefined>): number {
+  const seen = new Set([id]);
+  let depth = 0;
+  for (let cur = parents.get(id); cur !== undefined && parents.has(cur) && !seen.has(cur); ) {
+    depth++;
+    seen.add(cur);
+    cur = parents.get(cur);
+  }
+  return depth;
 }

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -7,8 +7,9 @@ export function formatCompact(n: number): string {
 /** Formats a token count compactly: 310334 -> "310.3k". */
 export const formatTokens = formatCompact;
 
+/** "-" for zero: traces without price data (AI SDK devtools) report 0. */
 export function formatCost(cost: number): string {
-  return `$${cost.toFixed(4)}`;
+  return cost > 0 ? `$${cost.toFixed(4)}` : "-";
 }
 
 export function formatSeconds(seconds: number): string {

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -45,6 +45,7 @@ export function normalizeTrace(raw: RawTrace): NormalizedTrace {
     totalLatency: sum(generations.map((g) => g.metrics.latency)),
     models: [...new Set(generations.map((g) => g.model))],
     segmentCount,
+    ...(raw.in_progress ? { inProgress: true } : {}),
     generations,
   };
 }
@@ -260,9 +261,13 @@ function normalizeEvent(
         : {}),
       inputTokens: event.metrics.tokens.input,
       outputTokens: event.metrics.tokens.output,
+      ...(event.metrics.tokens.reasoning !== undefined
+        ? { reasoningTokens: event.metrics.tokens.reasoning }
+        : {}),
       cost: event.metrics.cost,
     },
     toolCount: event.available_tools?.length ?? 0,
+    ...(event.in_progress ? { inProgress: true } : {}),
     carriedMessages: carried,
     foldedResults: rawNew - newMessages.length,
     newMessages,
@@ -329,7 +334,7 @@ function normalizeMessage(
   segment: number,
   pairing: Pairing,
 ): Message {
-  const text = contentToText(raw.content);
+  const { text, reasoning } = splitReasoning(raw.content);
   const toolCalls = raw.tool_calls?.map((call): PairedToolCall => {
     const key = `${segment}:${call.id}`;
     const result = pairing.results.get(key);
@@ -360,8 +365,31 @@ function normalizeMessage(
     index,
     role: normalizeRole(raw.role),
     text,
+    ...(reasoning !== undefined ? { reasoning } : {}),
     ...(toolCalls?.length ? { toolCalls } : {}),
     approxTokens: Math.round(messageChars(raw) / CHARS_PER_TOKEN),
+  };
+}
+
+/**
+ * Separates reasoning/thinking parts from the rest of a message's content.
+ * reasoning is defined (possibly "") only when such parts exist - providers
+ * that withhold thinking send parts with empty text.
+ */
+function splitReasoning(content: unknown): { text: string; reasoning?: string } {
+  if (!Array.isArray(content)) return { text: contentToText(content) };
+  const isReasoning = (part: unknown): part is { text?: string; thinking?: string } => {
+    const type = (part as { type?: unknown })?.type;
+    return type === "reasoning" || type === "thinking";
+  };
+  const parts = content.filter(isReasoning);
+  if (parts.length === 0) return { text: contentToText(content) };
+  return {
+    text: contentToText(content.filter((part) => !isReasoning(part))),
+    reasoning: parts
+      .map((part) => part.text ?? part.thinking ?? "")
+      .join("\n")
+      .trim(),
   };
 }
 

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -46,6 +46,7 @@ export function normalizeTrace(raw: RawTrace): NormalizedTrace {
     models: [...new Set(generations.map((g) => g.model))],
     segmentCount,
     ...(raw.in_progress ? { inProgress: true } : {}),
+    ...(raw.parent_trace_id !== undefined ? { parentTraceId: raw.parent_trace_id } : {}),
     generations,
   };
 }
@@ -577,6 +578,12 @@ function withoutResponse(messages: RawMessage[]): RawMessage[] {
 function scaleToReportedTokens(items: BreakdownItem[], inputTokens: number): void {
   const totalChars = sum(items.map((item) => item.chars));
   if (totalChars === 0) return;
+  // an in-flight generation has no usage yet - keep char-based estimates
+  // instead of scaling everything to a reported 0
+  if (inputTokens === 0) {
+    for (const item of items) item.estTokens = Math.round(item.chars / CHARS_PER_TOKEN);
+    return;
+  }
   for (const item of items) {
     item.estTokens = Math.round((item.chars / totalChars) * inputTokens);
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,8 @@ export interface RawTrace {
   name: string;
   total_tokens: { input: number; output: number };
   total_cost: number;
+  /** Adapter-provided: a generation is still running (live devtools). */
+  in_progress?: boolean;
   events: RawEvent[];
 }
 
@@ -13,6 +15,8 @@ export interface RawEvent {
   name: string;
   model: string;
   provider: string;
+  /** Adapter-provided: started but not finished (live devtools). */
+  in_progress?: boolean;
   metrics: {
     latency: number;
     time_to_first_token?: number;
@@ -21,6 +25,8 @@ export interface RawEvent {
       output: number;
       /** Provider-reported cache-read tokens, when the trace has real numbers. */
       cache_read?: number;
+      /** Provider-reported reasoning share of output tokens. */
+      reasoning?: number;
     };
     cost: number;
   };
@@ -62,6 +68,8 @@ export interface NormalizedTrace {
   totalLatency: number;
   models: string[];
   segmentCount: number;
+  /** True while a generation of this trace is still running (live devtools). */
+  inProgress?: boolean;
   generations: Generation[];
 }
 
@@ -78,9 +86,13 @@ export interface Generation {
     timeToFirstToken?: number;
     inputTokens: number;
     outputTokens: number;
+    /** Provider-reported reasoning share of output tokens, when known. */
+    reasoningTokens?: number;
     cost: number;
   };
   toolCount: number;
+  /** True while the generation is still running (live devtools). */
+  inProgress?: boolean;
   /** Count of context messages carried over from previous generations. */
   carriedMessages: number;
   /** Tool results folded into their calls instead of shown as messages. */
@@ -98,6 +110,11 @@ export interface Message {
   index: number;
   role: MessageRole;
   text: string;
+  /**
+   * Reasoning/thinking content, split out of the message text. Empty string
+   * when the provider reported thinking but withheld its content.
+   */
+  reasoning?: string;
   toolCalls?: PairedToolCall[];
   /** Rough size estimate (chars/4), not scaled to reported totals. */
   approxTokens: number;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,8 @@ export interface RawTrace {
   total_cost: number;
   /** Adapter-provided: a generation is still running (live devtools). */
   in_progress?: boolean;
+  /** Trace id of the run that spawned this one (nested agent runs). */
+  parent_trace_id?: string;
   events: RawEvent[];
 }
 
@@ -70,6 +72,8 @@ export interface NormalizedTrace {
   segmentCount: number;
   /** True while a generation of this trace is still running (live devtools). */
   inProgress?: boolean;
+  /** Trace id of the run that spawned this one (nested agent runs). */
+  parentTraceId?: string;
   generations: Generation[];
 }
 

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
 import { GenerationDetail } from "@/components/GenerationDetail";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Header } from "@/components/Header";
 import { ReplayBar } from "@/components/ReplayBar";
 import { RunList } from "@/components/RunList";
@@ -149,31 +150,55 @@ function Loaded({
   );
 }
 
+const REGISTER_SNIPPET = `import { registerTelemetry } from "ai";
+import { DevToolsTelemetry } from "@ai-sdk/devtools";
+
+registerTelemetry(DevToolsTelemetry());`;
+
 function WaitingForCalls() {
   return (
     <div className="flex flex-1 items-center justify-center p-8">
       <div className="w-full max-w-xl border border-ta-grey-400 bg-ta-grey-450">
-        <div className="flex items-baseline gap-3 border-b border-ta-grey-400 px-5 py-3">
-          <span className="size-2 shrink-0 animate-pulse self-center rounded-full bg-ta-orange-300" />
+        <div className="flex items-center gap-3 border-b border-ta-grey-400 px-5 py-3">
+          <span className="size-2 shrink-0 animate-pulse rounded-full bg-ta-orange-300" />
           <p className="type-accent-m text-ta-sand-50">waiting for AI SDK calls</p>
-          <p className="type-accent-s ml-auto text-ta-grey-200">listening on {location.host}</p>
+          <p className="type-accent-s ml-auto text-ta-grey-300">{location.host}</p>
         </div>
-        <div className="px-5 py-4">
-          <p className="type-body-m text-ta-grey-100">
-            Register the devtools telemetry in your app - every generateText / streamText call
-            streams in here live.
-          </p>
-          <pre className="type-body-s mt-4 overflow-x-auto border border-ta-grey-400 bg-ta-grey-500 px-4 py-3 font-(family-name:--font-dm-mono) leading-relaxed text-ta-sand-50">
-            {`import { registerTelemetry } from "ai";
-import { DevToolsTelemetry } from "@ai-sdk/devtools";
-
-registerTelemetry(DevToolsTelemetry());`}
-          </pre>
-          <p className="type-accent-s mt-4 text-ta-grey-200">
-            npm i @ai-sdk/devtools · runs persist in .devtools/generations.json
+        <div className="flex flex-col gap-5 px-5 py-5">
+          <SetupStep n={1} label="install">
+            <Snippet text="npm install @ai-sdk/devtools" />
+          </SetupStep>
+          <SetupStep n={2} label="register once at startup">
+            <Snippet text={REGISTER_SNIPPET} />
+          </SetupStep>
+          <p className="type-body-s text-ta-grey-200">
+            Every generateText / streamText call then appears here live. Runs persist in{" "}
+            <span className="font-(family-name:--font-dm-mono)">.devtools/generations.json</span>.
           </p>
         </div>
       </div>
+    </div>
+  );
+}
+
+function SetupStep({ n, label, children }: { n: number; label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="type-accent-s text-ta-grey-200">
+        <span className="text-ta-orange-300">{n}</span> · {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function Snippet({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 border border-ta-grey-400 bg-ta-grey-500 py-2 pl-4 pr-2">
+      <pre className="type-body-s min-w-0 flex-1 overflow-x-auto py-1 font-(family-name:--font-dm-mono) leading-relaxed text-ta-grey-100">
+        {text}
+      </pre>
+      <CopyButton className="border-none" text={text} />
     </div>
   );
 }

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -117,7 +117,8 @@ function Loaded({
         onClear={live ? () => void fetch("/api/clear", { method: "POST" }) : undefined}
       />
       <div className="flex min-h-0 flex-1">
-        <aside className="w-80 shrink-0 overflow-y-auto border-r border-ta-grey-400">
+        {/* stable gutters: a scrollbar appearing mid-stream must not shift the layout */}
+        <aside className="w-80 shrink-0 overflow-y-auto border-r border-ta-grey-400 [scrollbar-gutter:stable]">
           {runs.length > 1 && (
             <RunList runs={runs} selectedId={selectedRun} onSelect={onSelectRun} />
           )}
@@ -127,7 +128,7 @@ function Loaded({
             onSelect={selectGeneration}
           />
         </aside>
-        <main className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+        <main className="flex min-w-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]">
           {/* context + timeline fill exactly the first viewport; the rest scrolls in */}
           <div className="flex h-full shrink-0 flex-col">
             <TreemapSection trace={trace} generation={selected} />

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
 import { GenerationDetail } from "@/components/GenerationDetail";
 import { Header } from "@/components/Header";
 import { ReplayBar } from "@/components/ReplayBar";
+import { RunList } from "@/components/RunList";
 import { ToolCallsSection } from "@/components/ToolCallsSection";
 import { TreemapSection } from "@/components/TreemapSection";
 import { Waterfall } from "@/components/Waterfall";
@@ -10,7 +12,7 @@ import { useReplay } from "@/lib/use-replay";
 import { useTrace } from "@/lib/use-trace";
 
 export function App() {
-  const { trace, error } = useTrace();
+  const { runs, trace, error, live, selectedRun, selectRun } = useTrace();
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   if (error) {
@@ -21,6 +23,13 @@ export function App() {
     );
   }
   if (!trace) {
+    if (live && runs?.length === 0) {
+      return (
+        <Shell>
+          <WaitingForCalls />
+        </Shell>
+      );
+    }
     return (
       <Shell>
         <p className="type-accent-m p-8 text-ta-grey-200">loading trace...</p>
@@ -28,16 +37,38 @@ export function App() {
     );
   }
 
-  return <Loaded trace={trace} selectedIndex={selectedIndex} onSelect={setSelectedIndex} />;
+  return (
+    <Loaded
+      trace={trace}
+      runs={runs ?? []}
+      selectedRun={selectedRun}
+      onSelectRun={selectRun}
+      live={live}
+      selectedIndex={selectedIndex}
+      onSelect={setSelectedIndex}
+    />
+  );
 }
 
 interface LoadedProps {
   trace: NormalizedTrace;
+  runs: RunSummary[];
+  selectedRun?: string;
+  onSelectRun: (id: string) => void;
+  live: boolean;
   selectedIndex: number;
   onSelect: (index: number) => void;
 }
 
-function Loaded({ trace, selectedIndex, onSelect }: LoadedProps) {
+function Loaded({
+  trace,
+  runs,
+  selectedRun,
+  onSelectRun,
+  live,
+  selectedIndex,
+  onSelect,
+}: LoadedProps) {
   const replay = useReplay(trace);
 
   // follow the playhead: the entered generation becomes the selection
@@ -45,11 +76,28 @@ function Loaded({ trace, selectedIndex, onSelect }: LoadedProps) {
     if (replay.playing) onSelect(replay.currentIndex);
   }, [replay.playing, replay.currentIndex, onSelect]);
 
+  // run switches restart the selection; within a run, stick to the newest
+  // generation while live unless the user browsed away from the tail
+  const count = trace.generations.length;
+  const prev = useRef({ id: trace.traceId, count });
+  useEffect(() => {
+    const last = prev.current;
+    prev.current = { id: trace.traceId, count };
+    if (trace.traceId !== last.id) {
+      onSelect(trace.inProgress ? Math.max(count - 1, 0) : 0);
+      return;
+    }
+    if (!live || count <= last.count || replay.playing) return;
+    if (selectedIndex >= last.count - 1) onSelect(count - 1);
+  }, [trace.traceId, trace.inProgress, count, live, replay.playing, selectedIndex, onSelect]);
+
   const selected = trace.generations[selectedIndex] ?? trace.generations[0];
   if (!selected) {
     return (
       <Shell>
-        <p className="type-body-m p-8 text-ta-error">Trace has no generations.</p>
+        {live ? <WaitingForCalls /> : (
+          <p className="type-body-m p-8 text-ta-error">Trace has no generations.</p>
+        )}
       </Shell>
     );
   }
@@ -63,9 +111,15 @@ function Loaded({ trace, selectedIndex, onSelect }: LoadedProps) {
 
   return (
     <Shell>
-      <Header trace={trace} />
+      <Header
+        trace={trace}
+        onClear={live ? () => void fetch("/api/clear", { method: "POST" }) : undefined}
+      />
       <div className="flex min-h-0 flex-1">
         <aside className="w-80 shrink-0 overflow-y-auto border-r border-ta-grey-400">
+          {runs.length > 1 && (
+            <RunList runs={runs} selectedId={selectedRun} onSelect={onSelectRun} />
+          )}
           <Waterfall
             trace={trace}
             selectedIndex={selected.index}
@@ -92,6 +146,35 @@ function Loaded({ trace, selectedIndex, onSelect }: LoadedProps) {
         </main>
       </div>
     </Shell>
+  );
+}
+
+function WaitingForCalls() {
+  return (
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="w-full max-w-xl border border-ta-grey-400 bg-ta-grey-450">
+        <div className="flex items-baseline gap-3 border-b border-ta-grey-400 px-5 py-3">
+          <span className="size-2 shrink-0 animate-pulse self-center rounded-full bg-ta-orange-300" />
+          <p className="type-accent-m text-ta-sand-50">waiting for AI SDK calls</p>
+          <p className="type-accent-s ml-auto text-ta-grey-200">listening on {location.host}</p>
+        </div>
+        <div className="px-5 py-4">
+          <p className="type-body-m text-ta-grey-100">
+            Register the devtools telemetry in your app - every generateText / streamText call
+            streams in here live.
+          </p>
+          <pre className="type-body-s mt-4 overflow-x-auto border border-ta-grey-400 bg-ta-grey-500 px-4 py-3 font-(family-name:--font-dm-mono) leading-relaxed text-ta-sand-50">
+            {`import { registerTelemetry } from "ai";
+import { DevToolsTelemetry } from "@ai-sdk/devtools";
+
+registerTelemetry(DevToolsTelemetry());`}
+          </pre>
+          <p className="type-accent-s mt-4 text-ta-grey-200">
+            npm i @ai-sdk/devtools · runs persist in .devtools/generations.json
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/viewer/components/DefinitionDialog.tsx
+++ b/src/viewer/components/DefinitionDialog.tsx
@@ -9,7 +9,15 @@ import { prettyArgs, prettyPayload } from "@core/pretty";
 import type { TreemapLeaf } from "@/lib/treemap-data";
 
 /** Full definition of a clicked treemap block: pretty-rendered, raw JSON a toggle away. */
-export function DefinitionDialog({ leaf, onClose }: { leaf: TreemapLeaf; onClose: () => void }) {
+export function DefinitionDialog({
+  traceId,
+  leaf,
+  onClose,
+}: {
+  traceId: string;
+  leaf: TreemapLeaf;
+  onClose: () => void;
+}) {
   const [value, setValue] = useState<unknown>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [showRaw, setShowRaw] = useState(false);
@@ -18,13 +26,13 @@ export function DefinitionDialog({ leaf, onClose }: { leaf: TreemapLeaf; onClose
     let cancelled = false;
     setValue(undefined);
     setError(null);
-    fetchRawValue(leaf.ref)
+    fetchRawValue(traceId, leaf.ref)
       .then((v) => !cancelled && setValue(v))
       .catch((e) => !cancelled && setError(String(e)));
     return () => {
       cancelled = true;
     };
-  }, [leaf.ref]);
+  }, [traceId, leaf.ref]);
 
   const isTool = leaf.ref.includes("available_tools");
   return (
@@ -148,8 +156,10 @@ function Mono({ children }: { children: string }) {
 }
 
 /** Fetches a raw-trace value, failing legibly when the server is older than the viewer. */
-async function fetchRawValue(ref: string): Promise<unknown> {
-  const res = await fetch(`/api/raw?path=${encodeURIComponent(ref)}`);
+async function fetchRawValue(traceId: string, ref: string): Promise<unknown> {
+  const res = await fetch(
+    `/api/raw?id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(ref)}`,
+  );
   if (!res.headers.get("content-type")?.includes("application/json")) {
     throw new Error("this unbox-ai server is older than the viewer - restart it and reload");
   }

--- a/src/viewer/components/GenerationDetail.tsx
+++ b/src/viewer/components/GenerationDetail.tsx
@@ -27,10 +27,17 @@ export function GenerationDetail({ trace, generation }: GenerationDetailProps) {
       hint="generation"
       meta={
         <>
-          {generation.model} · {formatTokens(m.inputTokens)} in / {formatTokens(m.outputTokens)}{" "}
-          out · {formatSeconds(m.latency)}
-          {m.timeToFirstToken !== undefined && ` (ttft ${formatSeconds(m.timeToFirstToken)})`} ·{" "}
-          {formatCost(m.cost)} · {generation.toolCount} tools
+          {generation.model} · {formatTokens(m.inputTokens)} in / {formatTokens(m.outputTokens)}
+          {m.reasoningTokens !== undefined &&
+            ` (${formatTokens(m.reasoningTokens)} reasoning)`}{" "}
+          out ·{" "}
+          {generation.inProgress ? (
+            <span className="text-ta-orange-300">streaming...</span>
+          ) : (
+            formatSeconds(m.latency)
+          )}
+          {m.timeToFirstToken !== undefined && ` (ttft ${formatSeconds(m.timeToFirstToken)})`}
+          {m.cost > 0 && <> · {formatCost(m.cost)}</>} · {generation.toolCount} tools
         </>
       }
     >

--- a/src/viewer/components/Header.tsx
+++ b/src/viewer/components/Header.tsx
@@ -1,20 +1,29 @@
 import type { NormalizedTrace } from "@core/types";
 import { formatCost, formatSeconds, formatTokens } from "@core/format";
+import { Button } from "@/components/ui/button";
 import { Hint } from "@/components/ui/hint";
 
-export function Header({ trace }: { trace: NormalizedTrace }) {
+interface HeaderProps {
+  trace: NormalizedTrace;
+  /** Present in live devtools mode; empties the backing database. */
+  onClear?: () => void;
+}
+
+export function Header({ trace, onClear }: HeaderProps) {
   return (
     <header className="flex items-baseline gap-6 border-b border-ta-grey-400 px-6 py-4">
       <h1 className="type-accent-m text-ta-orange-300">unbox-ai</h1>
-      <span className="type-body-m text-ta-sand-50">{trace.name}</span>
+      <span className="type-body-m min-w-0 truncate text-ta-sand-50">{trace.name}</span>
       <span className="type-accent-s text-ta-grey-200">{trace.models.join(", ")}</span>
-      <div className="type-accent-s ml-auto flex gap-6 text-ta-grey-100">
+      <div className="type-accent-s ml-auto flex shrink-0 items-baseline gap-6 text-ta-grey-100">
         <Stat label={<Hint term="generation">generations</Hint>} value={String(trace.generations.length)} />
         <Stat label={<Hint term="segment">segments</Hint>} value={String(trace.segmentCount)} />
         <Stat label="in" value={formatTokens(trace.totalTokens.input)} />
         <Stat label="out" value={formatTokens(trace.totalTokens.output)} />
         <Stat label={<Hint term="model time">model time</Hint>} value={formatSeconds(trace.totalLatency)} />
-        <Stat label="cost" value={formatCost(trace.totalCost)} />
+        {/* traces without price data report 0 - a real run never costs exactly $0 */}
+        {trace.totalCost > 0 && <Stat label="cost" value={formatCost(trace.totalCost)} />}
+        {onClear && <Button onClick={onClear}>clear</Button>}
       </div>
     </header>
   );

--- a/src/viewer/components/MessageCard.tsx
+++ b/src/viewer/components/MessageCard.tsx
@@ -45,6 +45,7 @@ export function MessageCard({ message }: { message: Message }) {
           </pre>
         ) : (
           <>
+            {message.reasoning !== undefined && <Thinking reasoning={message.reasoning} />}
             {message.text && (
               <p className="type-body-s whitespace-pre-wrap text-ta-grey-100">
                 {text}
@@ -63,6 +64,42 @@ export function MessageCard({ message }: { message: Message }) {
         )}
       </div>
     </article>
+  );
+}
+
+const THINKING_PREVIEW_CHARS = 160;
+
+/** Collapsed reasoning content; providers that withhold it still leave a trace. */
+function Thinking({ reasoning }: { reasoning: string }) {
+  const [open, setOpen] = useState(false);
+  if (!reasoning) {
+    return (
+      <p className="type-accent-s mb-2 text-ta-grey-200">
+        thinking · content withheld by provider
+      </p>
+    );
+  }
+  const overflows = reasoning.length > THINKING_PREVIEW_CHARS;
+  return (
+    <div className="mb-2 border border-ta-grey-400 bg-ta-grey-500 px-3 py-2">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="type-accent-s flex w-full cursor-pointer items-center gap-2 text-left text-ta-sand-300"
+      >
+        <span>{open ? "▾" : "▸"} thinking</span>
+        <span className="text-ta-grey-200">~{formatTokens(Math.round(reasoning.length / 4))} tok</span>
+      </button>
+      <p
+        className={cn(
+          "type-body-s mt-1 whitespace-pre-wrap italic text-ta-grey-200",
+          !open && "truncate",
+        )}
+      >
+        {open ? reasoning : reasoning.slice(0, THINKING_PREVIEW_CHARS)}
+        {!open && overflows && " ..."}
+      </p>
+    </div>
   );
 }
 

--- a/src/viewer/components/RunList.tsx
+++ b/src/viewer/components/RunList.tsx
@@ -1,0 +1,67 @@
+import type { RunSummary } from "@core/collection";
+import { formatTokens } from "@core/format";
+import { cn } from "@/lib/utils";
+
+interface RunListProps {
+  runs: RunSummary[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+}
+
+/** Newest-first list of independent runs; each run opens as its own trace. */
+export function RunList({ runs, selectedId, onSelect }: RunListProps) {
+  return (
+    <div className="border-b border-ta-grey-400 pb-3">
+      <p className="type-accent-s mb-1 mt-4 px-4 text-ta-grey-200">
+        runs · {runs.length}
+      </p>
+      {runs
+        .map((run, number) => ({ run, number }))
+        .reverse()
+        .map(({ run, number }) => {
+          const selected = run.id === selectedId;
+          return (
+            <button
+              key={run.id}
+              onClick={() => onSelect(run.id)}
+              aria-pressed={selected}
+              title={`${formatTokens(run.totalTokens.input)} in / ${formatTokens(run.totalTokens.output)} out · ${run.models.join(", ")} · ${new Date(run.timestamp).toLocaleTimeString()}`}
+              className={cn(
+                "type-accent-s flex w-full cursor-pointer items-center gap-3 px-4 py-1.5 text-left transition-colors hover:bg-ta-grey-450",
+                selected && "bg-ta-grey-300/25",
+              )}
+            >
+              <span
+                className={cn(
+                  "w-5 shrink-0 text-right",
+                  selected ? "text-ta-orange-300" : "text-ta-grey-300",
+                )}
+              >
+                {number}
+              </span>
+              <span
+                className={cn(
+                  "min-w-0 flex-1 truncate",
+                  selected ? "text-ta-sand-50" : "text-ta-grey-100",
+                )}
+              >
+                {run.name}
+              </span>
+              <span
+                className={cn(
+                  "shrink-0",
+                  run.inProgress
+                    ? "text-ta-orange-300"
+                    : selected
+                      ? "text-ta-sand-50"
+                      : "text-ta-grey-200",
+                )}
+              >
+                {run.inProgress ? "live" : `${run.generations} gen`}
+              </span>
+            </button>
+          );
+        })}
+    </div>
+  );
+}

--- a/src/viewer/components/RunList.tsx
+++ b/src/viewer/components/RunList.tsx
@@ -15,9 +15,7 @@ export function RunList({ runs, selectedId, onSelect }: RunListProps) {
       <p className="type-accent-s mb-1 mt-4 px-4 text-ta-grey-200">
         runs · {runs.length}
       </p>
-      {runs
-        .map((run, number) => ({ run, number }))
-        .reverse()
+      {newestFirstTrees(runs)
         .map(({ run, number }) => {
           const selected = run.id === selectedId;
           return (
@@ -44,7 +42,9 @@ export function RunList({ runs, selectedId, onSelect }: RunListProps) {
                   "min-w-0 flex-1 truncate",
                   selected ? "text-ta-sand-50" : "text-ta-grey-100",
                 )}
+                style={run.depth > 0 ? { paddingLeft: run.depth * 12 } : undefined}
               >
+                {run.depth > 0 && <span className="text-ta-grey-300">↳ </span>}
                 {run.name}
               </span>
               <span
@@ -64,4 +64,17 @@ export function RunList({ runs, selectedId, onSelect }: RunListProps) {
         })}
     </div>
   );
+}
+
+/**
+ * Newest root first, but each root keeps its nested runs right below it -
+ * plain reversal would detach children (the list arrives depth-first).
+ */
+function newestFirstTrees(runs: RunSummary[]): { run: RunSummary; number: number }[] {
+  const trees: { run: RunSummary; number: number }[][] = [];
+  runs.forEach((run, number) => {
+    if (run.depth === 0 || trees.length === 0) trees.push([]);
+    trees.at(-1)!.push({ run, number });
+  });
+  return trees.reverse().flat();
 }

--- a/src/viewer/components/TreemapSection.tsx
+++ b/src/viewer/components/TreemapSection.tsx
@@ -96,7 +96,13 @@ export function TreemapSection({ trace, generation }: TreemapSectionProps) {
             <span className="text-ta-grey-200">hover a block to inspect it · click to pin its full definition</span>
           )}
         </div>
-        {pinned && <DefinitionDialog leaf={pinned} onClose={() => setPinnedId(null)} />}
+        {pinned && (
+          <DefinitionDialog
+            traceId={trace.traceId}
+            leaf={pinned}
+            onClose={() => setPinnedId(null)}
+          />
+        )}
       </div>
     </Section>
   );

--- a/src/viewer/components/Waterfall.tsx
+++ b/src/viewer/components/Waterfall.tsx
@@ -27,7 +27,7 @@ export function Waterfall({ trace, selectedIndex, onSelect }: WaterfallProps) {
             <button
               onClick={() => onSelect(gen.index)}
               aria-pressed={gen.index === selectedIndex}
-              title={`${formatTokens(gen.metrics.inputTokens)} in / ${formatTokens(gen.metrics.outputTokens)} out · ${formatCost(gen.metrics.cost)}`}
+              title={`${formatTokens(gen.metrics.inputTokens)} in / ${formatTokens(gen.metrics.outputTokens)} out${gen.metrics.cost > 0 ? ` · ${formatCost(gen.metrics.cost)}` : ""}`}
               className={cn(
                 "type-accent-s flex cursor-pointer items-center gap-3 px-4 py-1.5 text-left transition-colors hover:bg-ta-grey-450",
                 gen.index === selectedIndex && "bg-ta-grey-300/25",
@@ -52,10 +52,14 @@ export function Waterfall({ trace, selectedIndex, onSelect }: WaterfallProps) {
               <span
                 className={cn(
                   "shrink-0",
-                  gen.index === selectedIndex ? "text-ta-sand-50" : "text-ta-grey-200",
+                  gen.inProgress
+                    ? "text-ta-orange-300"
+                    : gen.index === selectedIndex
+                      ? "text-ta-sand-50"
+                      : "text-ta-grey-200",
                 )}
               >
-                {formatSeconds(gen.metrics.latency)}
+                {gen.inProgress ? "live" : formatSeconds(gen.metrics.latency)}
               </span>
             </button>
           </Fragment>

--- a/src/viewer/lib/use-trace.ts
+++ b/src/viewer/lib/use-trace.ts
@@ -1,26 +1,89 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
 
 interface TraceState {
+  /** One entry per independent run, chronological; absent until loaded. */
+  runs?: RunSummary[];
   trace?: NormalizedTrace;
+  selectedRun?: string;
   error?: string;
+  /** True when the server pushes updates (unbox-ai devtools mode). */
+  live: boolean;
 }
 
-/** Loads the normalized trace the CLI server exposes at /api/trace. */
-export function useTrace(): TraceState {
-  const [state, setState] = useState<TraceState>({});
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/trace")
-      .then(async (res) => {
-        if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
-        return res.json();
-      })
-      .then((trace) => !cancelled && setState({ trace }))
-      .catch((error) => !cancelled && setState({ error: String(error) }));
-    return () => {
-      cancelled = true;
-    };
+/**
+ * Loads the run list (/api/traces) and the selected run's trace
+ * (/api/trace?id=...), refetching both on every /api/events update push.
+ * Follows the newest run until the user picks an older one; the browser
+ * reconnects the event stream by itself after server restarts.
+ */
+export function useTrace(): TraceState & { selectRun: (id: string) => void } {
+  const [state, setState] = useState<TraceState>({ live: false });
+  const selectedRef = useRef<string | undefined>(undefined);
+  const pinnedRef = useRef(false);
+  const seqRef = useRef(0);
+  const loadRef = useRef(() => {});
+
+  const load = useCallback(async () => {
+    const seq = ++seqRef.current;
+    try {
+      const runs = (await fetchJson("/api/traces")) as RunSummary[];
+      const latest = runs.at(-1)?.id;
+      let selected = selectedRef.current;
+      if (
+        selected === undefined ||
+        !runs.some((run) => run.id === selected) ||
+        (!pinnedRef.current && selected !== latest)
+      ) {
+        selected = latest;
+        pinnedRef.current = false;
+      }
+      selectedRef.current = selected;
+      const trace =
+        selected === undefined
+          ? undefined
+          : ((await fetchJson(`/api/trace?id=${encodeURIComponent(selected)}`)) as NormalizedTrace);
+      // update bursts overlap; only the newest request may win
+      if (seq !== seqRef.current) return;
+      setState((prev) => ({ ...prev, runs, trace, selectedRun: selected, error: undefined }));
+    } catch (error) {
+      if (seq !== seqRef.current) return;
+      // a transient refetch failure must not blank an already-loaded trace
+      setState((prev) => (prev.trace ? prev : { ...prev, error: String(error) }));
+    }
   }, []);
-  return state;
+  loadRef.current = load;
+
+  useEffect(() => {
+    load();
+    const events = new EventSource("/api/events");
+    events.addEventListener("hello", (e) => {
+      const live = (JSON.parse(e.data) as { live?: boolean }).live === true;
+      setState((prev) => ({ ...prev, live }));
+    });
+    events.addEventListener("update", () => loadRef.current());
+    return () => {
+      seqRef.current++;
+      events.close();
+    };
+  }, [load]);
+
+  const selectRun = useCallback(
+    (id: string) => {
+      selectedRef.current = id;
+      // picking an older run pins it; picking the newest resumes following
+      pinnedRef.current = id !== state.runs?.at(-1)?.id;
+      load();
+    },
+    [load, state.runs],
+  );
+
+  return { ...state, selectRun };
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
+  return res.json();
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,39 +13,55 @@ function devTraceApi(): Plugin {
   return {
     name: "unbox-dev-trace-api",
     async configureServer(server) {
-      const { normalizeTrace } = await import("./src/core/normalize");
-      const { parseTrace } = await import("./src/core/adapters");
+      const { parseCollection, runSummaries } = await import("./src/core/collection");
       const { resolvePath } = await import("./src/core/path");
+      const loadItems = () => {
+        const tracePath = process.env.UNBOX_TRACE;
+        if (!tracePath) throw new Error("Set UNBOX_TRACE=<file> to serve a trace in dev");
+        return parseCollection(JSON.parse(readFileSync(tracePath, "utf8"))).items;
+      };
+      const pick = (req: { url?: string }) => {
+        const url = new URL(req.url ?? "", "http://localhost");
+        const items = loadItems();
+        const id = url.searchParams.get("id");
+        const item =
+          id === null ? items.at(-1) : items.find((it) => it.trace.traceId === id);
+        return { url, item };
+      };
+      const send = (res: import("node:http").ServerResponse, status: number, body: unknown) => {
+        res.statusCode = status;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify(body));
+      };
       server.middlewares.use("/api/raw", (req, res) => {
         try {
-          const raw = parseTrace(JSON.parse(readFileSync(process.env.UNBOX_TRACE ?? "", "utf8")));
-          const path = new URL(req.url ?? "", "http://localhost").searchParams.get("path") ?? "";
-          const value = resolvePath(raw, path);
-          res.statusCode = value === undefined ? 404 : 200;
-          res.setHeader("content-type", "application/json");
-          res.end(JSON.stringify(value === undefined ? { error: "nothing at path" } : { value }));
+          const { url, item } = pick(req);
+          const value = item && resolvePath(item.raw, url.searchParams.get("path") ?? "");
+          if (value === undefined) return send(res, 404, { error: "nothing at path" });
+          send(res, 200, { value });
         } catch (error) {
-          res.statusCode = 500;
-          res.end(JSON.stringify({ error: String(error) }));
+          send(res, 500, { error: String(error) });
         }
       });
-      server.middlewares.use("/api/trace", (_req, res) => {
-        const sendError = (message: string) => {
-          res.statusCode = 500;
-          res.setHeader("content-type", "application/json");
-          res.end(JSON.stringify({ error: message }));
-        };
-        const tracePath = process.env.UNBOX_TRACE;
-        if (!tracePath) {
-          sendError("Set UNBOX_TRACE=<file> to serve a trace in dev");
-          return;
-        }
+      // static stand-in for the CLI's SSE endpoint so EventSource connects in dev
+      server.middlewares.use("/api/events", (_req, res) => {
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        res.write('event: hello\ndata: {"live":false}\n\n');
+      });
+      server.middlewares.use("/api/traces", (_req, res) => {
         try {
-          const raw = parseTrace(JSON.parse(readFileSync(tracePath, "utf8")));
-          res.setHeader("content-type", "application/json");
-          res.end(JSON.stringify(normalizeTrace(raw)));
+          send(res, 200, runSummaries(loadItems()));
         } catch (error) {
-          sendError(error instanceof Error ? error.message : String(error));
+          send(res, 500, { error: error instanceof Error ? error.message : String(error) });
+        }
+      });
+      server.middlewares.use("/api/trace", (req, res) => {
+        try {
+          const { item } = pick(req);
+          if (!item) return send(res, 404, { error: "no traces yet" });
+          send(res, 200, item.trace);
+        } catch (error) {
+          send(res, 500, { error: error instanceof Error ? error.message : String(error) });
         }
       });
     },


### PR DESCRIPTION
## What

Makes unbox-ai a drop-in replacement for the @ai-sdk/devtools viewer, plus first-class support for its database format everywhere else.

### Adapter (static)
- Auto-detects `.devtools/generations.json` (`{runs[], steps[]}`). Key mapping insight: `prompt(N+1) === prompt(N) + response.messages(N)` verbatim, so appending each step's response to its prompt snapshot feeds the existing cumulative-snapshot pipeline unchanged - segments, tool pairing, cache attribution all work with zero core changes.
- Cache-read and reasoning tokens carry over; cost prints `-` (the AI SDK reports no dollars).

### Live mode
- `npx unbox-ai devtools` - user instruments with `registerTelemetry(DevToolsTelemetry())` per Vercel's own docs, runs this instead of `npx @ai-sdk/devtools`.
- Ingests the integration's `POST /api/notify` pings, re-reads the db, pushes SSE updates; viewer refetches live. Binds both `127.0.0.1` and `::1` on an exact port (the app notifies `localhost`, which can resolve to either). Mid-write reads keep the last good state.
- Clear button empties the db file (survives app restarts).

### Runs
- Every run - root or nested - is its own trace with its own run-list entry, children indented under their parent. Newest root first; the viewer follows the newest run until you pin an older one, and tails the newest generation while live.
- Children are listed separately (not bundled into the parent) deliberately: @ai-sdk/devtools tracks the currently-executing tool in a process-wide singleton, so a second concurrent streamText can be recorded as a nested child of the first. Bundling would make such a run invisible; separate entries keep concurrent live streams individually visible and switchable. (Upstream bug worth reporting to vercel/ai.)
- Generalizes: `unbox-ai view a.trace.json b.trace.json` opens any mix of formats as one run list.

### Agent CLI
- `unbox-ai runs <db>` (tree-indented, `[live]` markers) + `--run <n|id>` on all text commands, with run-local indexes and printed `get` pointers that carry the flag. Works mid-run against the live file. Skill updated to teach the workflow.

### Viewer UX (ported from a full sweep of the original devtools source)
- Collapsed thinking blocks with token estimates ("content withheld by provider" for encrypted reasoning), reasoning tokens in generation meta, streaming placeholders, waiting screen with setup snippet, no fabricated $0 costs, char-based treemap for in-flight generations.
- Deliberately not ported: their timeline sub-span timing (fabricates durations) and the media preview subsystem.

## Test plan

- [x] Fixture db generated with real `ai@7.0.79` + `@ai-sdk/devtools@1.0.13` (mock models: multi-step, parallel tool calls, cache reads, nested child run); CLI summary/event/messages/tools verified against it
- [x] Live end-to-end in a browser: waiting screen -> runs stream in -> auto-follow -> pin older run -> clear -> waiting; SSE reconnect after server restart
- [x] Two concurrent live streams (the mis-attribution case): both runs visible and switchable mid-flight, both marked live
- [x] Verified against a real 7.6MB QA-agent db (6 runs incl. in-progress) - run labels, [live] markers, --run scoping, scoped pointers
- [x] Regressions: gateway + opencode traces via summary/view, static /api endpoints, typecheck + build clean