### PR TITLE
chore: repo tooling - biome, vitest, ci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Overview
+
+<!-- What this PR does and why. -->
+
+## Test plan
+
+<!-- How you verified it: commands run, traces viewed, screenshots. -->
+
+- [ ] `npm run check` passes (lint + typecheck + tests)
+- [ ] Verified against a real trace/db where the change is user-visible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.log
 .DS_Store
 *.trace.json
+.tmp-vitest-live/

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ npm install
 UNBOX_TRACE=path/to/trace.json npm run dev   # viewer with live reload
 npm run build                                 # dist/viewer + dist/cli
 node dist/cli/index.js summary path/to/trace.json
+npm run check                                 # lint (biome) + typecheck + tests (vitest)
 ```
 
 ## License

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "files": {
+    "includes": ["**", "!src/viewer/public", "!**/*.css"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "useExhaustiveDependencies": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "a11y": {
+        "noStaticElementInteractions": "off"
+      }
+    }
+  },
+  "css": {
+    "formatter": {
+      "enabled": false
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "unbox-ai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unbox-ai",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
         "unbox-ai": "dist/cli/index.js"
       },
       "devDependencies": {
         "@base-ui-components/react": "1.0.0-rc.0",
+        "@biomejs/biome": "^2.5.10",
         "@tailwindcss/vite": "4.3.3",
         "@types/d3-hierarchy": "3.1.7",
         "@types/node": "26.2.0",
@@ -30,7 +31,8 @@
         "tsup": "8.5.1",
         "tw-animate-css": "1.4.0",
         "typescript": "5.9.3",
-        "vite": "8.2.2"
+        "vite": "8.2.2",
+        "vitest": "^4.1.11"
       },
       "engines": {
         "node": ">=18"
@@ -102,6 +104,181 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.10.tgz",
+      "integrity": "sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.10",
+        "@biomejs/cli-darwin-x64": "2.5.10",
+        "@biomejs/cli-linux-arm64": "2.5.10",
+        "@biomejs/cli-linux-arm64-musl": "2.5.10",
+        "@biomejs/cli-linux-x64": "2.5.10",
+        "@biomejs/cli-linux-x64-musl": "2.5.10",
+        "@biomejs/cli-win32-arm64": "2.5.10",
+        "@biomejs/cli-win32-x64": "2.5.10"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.10.tgz",
+      "integrity": "sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.10.tgz",
+      "integrity": "sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.10.tgz",
+      "integrity": "sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.10.tgz",
+      "integrity": "sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.10.tgz",
+      "integrity": "sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.10.tgz",
+      "integrity": "sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.10.tgz",
+      "integrity": "sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.10.tgz",
+      "integrity": "sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1337,6 +1514,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
@@ -1621,6 +1805,17 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-hierarchy": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
@@ -1637,6 +1832,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1756,6 +1958,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1775,6 +2090,16 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -1822,6 +2147,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -1932,6 +2267,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2029,6 +2371,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -2093,6 +2442,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -3567,6 +3936,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -3965,6 +4348,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3995,6 +4385,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4116,6 +4520,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -4138,6 +4549,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -4752,6 +5173,123 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,12 @@
     "build:viewer": "vite build",
     "dev": "vite",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "npm run lint && npm run typecheck && npm run test",
+    "prepublishOnly": "npm run check && npm run build"
   },
   "devDependencies": {
     "@base-ui-components/react": "1.0.0-rc.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@base-ui-components/react": "1.0.0-rc.0",
+    "@biomejs/biome": "^2.5.10",
     "@tailwindcss/vite": "4.3.3",
     "@types/d3-hierarchy": "3.1.7",
     "@types/node": "26.2.0",
@@ -54,6 +55,7 @@
     "tsup": "8.5.1",
     "tw-animate-css": "1.4.0",
     "typescript": "5.9.3",
-    "vite": "8.2.2"
+    "vite": "8.2.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/src/cli/commands/event.ts
+++ b/src/cli/commands/event.ts
@@ -23,7 +23,8 @@ export function event(loaded: LoadedTrace, index: number, json: boolean): void {
     return;
   }
   const m = gen.metrics;
-  const ttft = m.timeToFirstToken !== undefined ? ` (ttft ${formatSeconds(m.timeToFirstToken)})` : "";
+  const ttft =
+    m.timeToFirstToken !== undefined ? ` (ttft ${formatSeconds(m.timeToFirstToken)})` : "";
   console.log(
     `generation ${gen.index}  seg ${gen.segment}  ${gen.model}  ` +
       `${formatTokens(m.inputTokens)} in / ${formatTokens(m.outputTokens)} out  ` +
@@ -43,11 +44,13 @@ export function event(loaded: LoadedTrace, index: number, json: boolean): void {
       : `context: fresh conversation, ${gen.newMessages.length} messages${folded}`,
   );
   console.log("");
-  gen.newMessages.forEach((message) => printMessage(message, gen.index));
+  for (const message of gen.newMessages) printMessage(message, gen.index);
 }
 
 function printMessage(message: Message, genIndex: number): void {
-  console.log(`--- [${message.index}] ${message.role} (~${formatTokens(message.approxTokens)} tok)`);
+  console.log(
+    `--- [${message.index}] ${message.role} (~${formatTokens(message.approxTokens)} tok)`,
+  );
   if (message.reasoning !== undefined) {
     console.log(
       message.reasoning

--- a/src/cli/commands/events.ts
+++ b/src/cli/commands/events.ts
@@ -1,6 +1,13 @@
 import { toolCallNames } from "../../core/normalize";
 import type { LoadedTrace } from "../load";
-import { formatCallNames, formatCost, formatSeconds, formatTokens, printJson, table } from "../output";
+import {
+  formatCallNames,
+  formatCost,
+  formatSeconds,
+  formatTokens,
+  printJson,
+  table,
+} from "../output";
 
 /** Prints one table row per generation. */
 export function events(loaded: LoadedTrace, json: boolean): void {

--- a/src/cli/commands/messages.ts
+++ b/src/cli/commands/messages.ts
@@ -24,7 +24,7 @@ export function messages(loaded: LoadedTrace, filter: MessagesFilter, json: bool
   const hits = loaded.trace.generations.flatMap((gen) =>
     gen.newMessages
       .filter((m) => filter.role === undefined || m.role === filter.role)
-      .filter((m) => filter.event === undefined || gen.index === filter.event)
+      .filter(() => filter.event === undefined || gen.index === filter.event)
       .map((m) => ({ gen: gen.index, match: findMatch(m, pattern), ...m }))
       .filter((hit) => hit.match !== null),
   );
@@ -52,7 +52,9 @@ export function messages(loaded: LoadedTrace, filter: MessagesFilter, json: bool
     );
   }
   if (hits.length > shown.length) {
-    console.log(`\n${hits.length - shown.length} more - narrow with --grep/--role/--event or raise --limit`);
+    console.log(
+      `\n${hits.length - shown.length} more - narrow with --grep/--role/--event or raise --limit`,
+    );
   }
 }
 
@@ -81,7 +83,5 @@ function findMatch(m: Message, pattern: RegExp | undefined): Match | null {
 
 function snippet(text: string, pattern: RegExp): string {
   const index = text.search(pattern);
-  return text
-    .slice(Math.max(0, index - 60), index + 160)
-    .replace(/\s+/g, " ");
+  return text.slice(Math.max(0, index - 60), index + 160).replace(/\s+/g, " ");
 }

--- a/src/cli/commands/summary.ts
+++ b/src/cli/commands/summary.ts
@@ -2,7 +2,14 @@ import { formatPercent } from "../../core/format";
 import { computeInsights } from "../../core/insights";
 import { toolCallNames } from "../../core/normalize";
 import type { LoadedTrace } from "../load";
-import { formatCallNames, formatCost, formatSeconds, formatTokens, getTraceRef, printJson } from "../output";
+import {
+  formatCallNames,
+  formatCost,
+  formatSeconds,
+  formatTokens,
+  getTraceRef,
+  printJson,
+} from "../output";
 
 /** Prints trace totals plus a one-liner per generation. */
 export function summary(loaded: LoadedTrace, json: boolean): void {

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -27,7 +27,10 @@ export function tools(loaded: LoadedTrace, json: boolean, all: boolean): void {
       status(call.success, call.result !== undefined),
       call.durationMs !== undefined ? formatMs(call.durationMs) : "-",
       call.result !== undefined ? formatCompact(call.result.length) : "-",
-      truncate(JSON.stringify(call.args) ?? "", undefined, ARGS_PREVIEW_CHARS).replace(/\n.*/s, "..."),
+      truncate(JSON.stringify(call.args) ?? "", undefined, ARGS_PREVIEW_CHARS).replace(
+        /\n.*/s,
+        "...",
+      ),
     ]);
     console.log(table(["gen", "name", "status", "time", "size", "args"], rows));
     console.log(`\ndrill in: unbox-ai event ${getTraceRef()} <gen>`);
@@ -56,7 +59,9 @@ export function tools(loaded: LoadedTrace, json: boolean, all: boolean): void {
       formatCompact(u.totalSize),
     ]);
   console.log(table(["tool", "calls", "failed", "time", "output"], rows));
-  console.log(`\n${calls.length} calls across ${byName.size} tools · every call: unbox-ai tools ${getTraceRef()} --all`);
+  console.log(
+    `\n${calls.length} calls across ${byName.size} tools · every call: unbox-ai tools ${getTraceRef()} --all`,
+  );
 }
 
 function status(success: boolean | undefined, hasResult: boolean): string {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,13 +1,13 @@
-import { parseArgs } from "node:util";
 import { resolve } from "node:path";
+import { parseArgs } from "node:util";
 import type { MessageRole } from "../core/types";
 import { event } from "./commands/event";
 import { events } from "./commands/events";
 import { get } from "./commands/get";
 import { messages } from "./commands/messages";
+import { runs } from "./commands/runs";
 import { summary } from "./commands/summary";
 import { tools } from "./commands/tools";
-import { runs } from "./commands/runs";
 import { createLiveSource } from "./live";
 import { fail, loadCollectionFiles, loadRun, loadTrace } from "./load";
 import { openBrowser } from "./open-browser";
@@ -42,7 +42,16 @@ Plain output is bounded; truncations include the exact "get" invocation
 that returns the rest. --json is complete and therefore unbounded.
 All commands are read-only - safe for agents to run freely.`;
 
-const COMMANDS = new Set(["view", "runs", "summary", "events", "event", "tools", "messages", "get"]);
+const COMMANDS = new Set([
+  "view",
+  "runs",
+  "summary",
+  "events",
+  "event",
+  "tools",
+  "messages",
+  "get",
+]);
 
 const ROLES: MessageRole[] = ["system", "user", "assistant", "tool-result", "unknown"];
 
@@ -75,9 +84,7 @@ function main(): void {
 
   const [first, ...rest] = positionals;
   if (first === "devtools") {
-    devtools(values).catch((error) =>
-      fail(error instanceof Error ? error.message : String(error)),
-    );
+    devtools(values).catch((error) => fail(error instanceof Error ? error.message : String(error)));
     return;
   }
   const command = COMMANDS.has(first!) ? first! : defaultCommand();
@@ -136,10 +143,7 @@ function defaultCommand(): string {
   return process.stdout.isTTY ? "view" : "summary";
 }
 
-async function view(
-  paths: string[],
-  values: { port?: string; "no-open": boolean },
-): Promise<void> {
+async function view(paths: string[], values: { port?: string; "no-open": boolean }): Promise<void> {
   const items = loadCollectionFiles(paths);
   if (items.length === 0) fail("No runs found in the given files.");
   const { port } = await startServer(staticSource(items), parsePort(values.port ?? "4177"));

--- a/src/cli/load.ts
+++ b/src/cli/load.ts
@@ -48,7 +48,9 @@ export function loadRun(path: string, selector: string): LoadedTrace {
       ? items[Number(selector)]
       : items.find(({ trace }) => trace.traceId === selector);
     if (!item) {
-      throw new Error(`No run "${selector}" (${items.length} runs). List them: unbox-ai runs ${path}`);
+      throw new Error(
+        `No run "${selector}" (${items.length} runs). List them: unbox-ai runs ${path}`,
+      );
     }
     return { path, format, raw: item.raw, trace: item.trace };
   } catch (error) {

--- a/src/cli/open-browser.ts
+++ b/src/cli/open-browser.ts
@@ -8,5 +8,7 @@ export function openBrowser(url: string): void {
       : process.platform === "win32"
         ? ["cmd", ["/c", "start", "", url]]
         : ["xdg-open", [url]];
-  spawn(command, args, { stdio: "ignore", detached: true }).on("error", () => {}).unref();
+  spawn(command, args, { stdio: "ignore", detached: true })
+    .on("error", () => {})
+    .unref();
 }

--- a/src/cli/server.test.ts
+++ b/src/cli/server.test.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { request, type Server } from "node:http";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { normalizeTrace } from "../core/normalize";
+import type { RawTrace } from "../core/types";
+import { createLiveSource } from "./live";
+import { startServer, staticSource } from "./server";
+
+const raw: RawTrace = {
+  trace_id: "t1",
+  timestamp: "2026-08-25T10:00:00.000Z",
+  name: "test",
+  total_tokens: { input: 1, output: 1 },
+  total_cost: 0,
+  events: [
+    {
+      type: "generation",
+      name: "agent",
+      model: "test-model",
+      provider: "p",
+      metrics: { latency: 1, tokens: { input: 1, output: 1 }, cost: 0 },
+      messages: [{ role: "user", content: "hi" }],
+    },
+  ],
+};
+
+const servers: Server[] = [];
+afterAll(() => {
+  for (const server of servers) server.close();
+});
+
+async function serve(source = staticSource([{ raw, trace: normalizeTrace(raw) }])) {
+  // a random high port keeps parallel test runs from colliding
+  const port = 21000 + Math.floor(Math.random() * 20000);
+  const bound = await startServer(source, port);
+  servers.push(...bound.servers);
+  return { base: `http://127.0.0.1:${bound.port}`, port: bound.port };
+}
+
+describe("api routes", () => {
+  it("serves the run list and id-addressed traces", async () => {
+    const { base } = await serve();
+    const list = (await (await fetch(`${base}/api/traces`)).json()) as { id: string }[];
+    expect(list).toHaveLength(1);
+
+    const trace = await (await fetch(`${base}/api/trace?id=${list[0]!.id}`)).json();
+    expect((trace as { traceId: string }).traceId).toBe("t1");
+
+    expect((await fetch(`${base}/api/trace?id=nope`)).status).toBe(404);
+    expect((await fetch(`${base}/api/unknown`)).status).toBe(404);
+  });
+
+  it("resolves raw paths against the addressed trace", async () => {
+    const { base } = await serve();
+    const res = await fetch(`${base}/api/raw?id=t1&path=${encodeURIComponent("events[0].model")}`);
+    expect(((await res.json()) as { value: string }).value).toBe("test-model");
+  });
+
+  it("announces the mode over the event stream", async () => {
+    const { base } = await serve();
+    const res = await fetch(`${base}/api/events`);
+    const reader = res.body!.getReader();
+    const frame = new TextDecoder().decode((await reader.read()).value);
+    expect(frame).toContain("event: hello");
+    expect(frame).toContain('{"live":false}');
+    await reader.cancel();
+  });
+});
+
+describe("request guards", () => {
+  it("rejects foreign Hosts (DNS rebinding) and Origins (cross-site)", async () => {
+    const { base, port } = await serve();
+    // fetch forbids overriding Host, so speak raw http for the rebinding case
+    const rebind = await new Promise<number>((resolve, reject) => {
+      const req = request(
+        { host: "127.0.0.1", port, path: "/api/trace", headers: { host: `evil.example:${port}` } },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    expect(rebind).toBe(403);
+
+    const crossSite = await fetch(`${base}/api/trace`, {
+      headers: { origin: "https://evil.example" },
+    });
+    expect(crossSite.status).toBe(403);
+
+    const sameOrigin = await fetch(`${base}/api/trace`, {
+      headers: { origin: `http://127.0.0.1:${port}` },
+    });
+    expect(sameOrigin.status).toBe(200);
+  });
+
+  it("exposes notify and clear only on live sources", async () => {
+    const { base } = await serve();
+    expect((await fetch(`${base}/api/notify`, { method: "POST" })).status).toBe(404);
+    expect((await fetch(`${base}/api/clear`, { method: "POST" })).status).toBe(404);
+  });
+});
+
+describe("live mode", () => {
+  // must live under cwd - notify rejects paths outside the viewer's workspace
+  const dir = join(process.cwd(), ".tmp-vitest-live", ".devtools");
+  const dbPath = join(dir, "generations.json");
+  afterAll(() => rmSync(join(process.cwd(), ".tmp-vitest-live"), { recursive: true, force: true }));
+
+  function writeDb(runs: number) {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      dbPath,
+      JSON.stringify({
+        runs: Array.from({ length: runs }, (_, i) => ({
+          id: `run-${i}`,
+          started_at: "2026-08-25T10:00:00.000Z",
+          parent_run_id: null,
+          parent_step_id: null,
+          function_id: null,
+        })),
+        steps: [],
+      }),
+    );
+  }
+
+  it("ingests notify pings, validates paths, and clears the database", async () => {
+    writeDb(1);
+    const source = createLiveSource(dbPath);
+    source.reload();
+    const { base } = await serve(source);
+
+    expect(((await (await fetch(`${base}/api/traces`)).json()) as unknown[]).length).toBe(1);
+
+    writeDb(2);
+    const notify = await fetch(`${base}/api/notify`, {
+      method: "POST",
+      body: JSON.stringify({ event: "run", dbPath }),
+    });
+    expect(notify.status).toBe(200);
+    expect(((await (await fetch(`${base}/api/traces`)).json()) as unknown[]).length).toBe(2);
+
+    const outside = await fetch(`${base}/api/notify`, {
+      method: "POST",
+      body: JSON.stringify({ dbPath: "/tmp/elsewhere/.devtools/generations.json" }),
+    });
+    expect(outside.status).toBe(400);
+
+    const cleared = await fetch(`${base}/api/clear`, { method: "POST" });
+    expect(cleared.status).toBe(200);
+    expect(((await (await fetch(`${base}/api/traces`)).json()) as unknown[]).length).toBe(0);
+  });
+
+  it("drops oversized notify bodies without dying", async () => {
+    writeDb(1);
+    const source = createLiveSource(dbPath);
+    const { base } = await serve(source);
+
+    await expect(
+      fetch(`${base}/api/notify`, { method: "POST", body: "x".repeat(128 * 1024) }),
+    ).rejects.toThrow();
+    // the server survives the dropped connection
+    expect((await fetch(`${base}/api/traces`)).status).toBe(200);
+  });
+});

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -1,5 +1,5 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { extname, join, normalize, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSummaries, type TraceCollectionItem } from "../core/collection";
@@ -90,7 +90,8 @@ export async function startServer(
     // must come from a page this server itself served
     if (url.pathname.startsWith("/api/")) {
       const { host, origin } = req.headers;
-      const originHost = typeof origin === "string" ? origin.replace(/^https?:\/\//, "") : undefined;
+      const originHost =
+        typeof origin === "string" ? origin.replace(/^https?:\/\//, "") : undefined;
       if (
         host === undefined ||
         !allowedHosts().has(host) ||
@@ -158,9 +159,7 @@ export async function startServer(
     } catch {
       // SPA fallback for extension-less deep links only; missing assets stay a hard 404
       const index =
-        extname(path) === ""
-          ? await readFile(join(dir, "index.html")).catch(() => null)
-          : null;
+        extname(path) === "" ? await readFile(join(dir, "index.html")).catch(() => null) : null;
       if (index) {
         res.writeHead(200, { "content-type": "text/html" }).end(index);
       } else {

--- a/src/core/adapters/ai-sdk-devtools.test.ts
+++ b/src/core/adapters/ai-sdk-devtools.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTrace } from "../normalize";
+import { aiSdkDevtoolsAdapter } from "./ai-sdk-devtools";
+
+interface StepOverrides {
+  run_id?: string;
+  step_number?: number;
+  model_id?: string;
+  duration_ms?: number | null;
+  input?: unknown;
+  output?: unknown;
+  usage?: unknown;
+  error?: string | null;
+}
+
+const SYSTEM = { role: "system", content: "You are a weather bot." };
+const USER = { role: "user", content: [{ type: "text", text: "Weather in SF?" }] };
+const ASSISTANT_CALL = {
+  role: "assistant",
+  content: [
+    { type: "reasoning", text: "Need the tool." },
+    { type: "tool-call", toolCallId: "call_1", toolName: "getWeather", input: { city: "SF" } },
+  ],
+};
+const TOOL_RESULT = {
+  role: "tool",
+  content: [
+    {
+      type: "tool-result",
+      toolCallId: "call_1",
+      toolName: "getWeather",
+      output: { type: "json", value: { tempC: 18 } },
+    },
+  ],
+};
+const ASSISTANT_ANSWER = {
+  role: "assistant",
+  content: [{ type: "text", text: "18C and sunny." }],
+};
+
+const USAGE = {
+  inputTokens: 100,
+  inputTokenDetails: { noCacheTokens: 100, cacheReadTokens: 0, cacheWriteTokens: 0 },
+  outputTokens: 20,
+  outputTokenDetails: { textTokens: 15, reasoningTokens: 5 },
+  totalTokens: 120,
+};
+
+function step(overrides: StepOverrides = {}) {
+  const { input, output, usage, ...rest } = overrides;
+  return {
+    id: `step-${rest.run_id ?? "r1"}-${rest.step_number ?? 1}`,
+    run_id: "r1",
+    step_number: 1,
+    type: "generate",
+    model_id: "test-model",
+    provider: "test",
+    started_at: "2026-08-25T10:00:00.000Z",
+    duration_ms: 150,
+    input: JSON.stringify(input ?? { prompt: [SYSTEM, USER] }),
+    output: output === null ? null : JSON.stringify(output ?? { response: { messages: [] } }),
+    usage: usage === null ? null : JSON.stringify(usage ?? USAGE),
+    error: null,
+    ...rest,
+  };
+}
+
+function run(id: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    started_at: "2026-08-25T10:00:00.000Z",
+    parent_run_id: null,
+    parent_step_id: null,
+    function_id: null,
+    ...extra,
+  };
+}
+
+/** A two-step tool-using run: the shape the telemetry integration writes. */
+function twoStepDb() {
+  return {
+    runs: [run("r1")],
+    steps: [
+      step({
+        step_number: 1,
+        input: { prompt: [SYSTEM, USER], tools: [{ name: "getWeather", description: "d" }] },
+        output: { response: { messages: [ASSISTANT_CALL, TOOL_RESULT] } },
+      }),
+      step({
+        step_number: 2,
+        input: { prompt: [SYSTEM, USER, ASSISTANT_CALL, TOOL_RESULT] },
+        output: { response: { messages: [ASSISTANT_ANSWER] } },
+        usage: { ...USAGE, inputTokens: 130, inputTokenDetails: { cacheReadTokens: 100 } },
+      }),
+    ],
+  };
+}
+
+describe("detect", () => {
+  it("accepts a devtools database", () => {
+    expect(aiSdkDevtoolsAdapter.detect(twoStepDb())).toBe(true);
+    expect(aiSdkDevtoolsAdapter.detect({ runs: [], steps: [] })).toBe(true);
+  });
+
+  it("rejects other trace shapes", () => {
+    expect(aiSdkDevtoolsAdapter.detect({ events: [] })).toBe(false);
+    expect(aiSdkDevtoolsAdapter.detect({ info: {}, messages: [] })).toBe(false);
+    expect(aiSdkDevtoolsAdapter.detect({ runs: [{}], steps: [] })).toBe(false);
+    expect(aiSdkDevtoolsAdapter.detect(null)).toBe(false);
+  });
+});
+
+describe("adapt", () => {
+  it("keeps a multi-step run in one segment with paired tool calls", () => {
+    const trace = normalizeTrace(aiSdkDevtoolsAdapter.adapt(twoStepDb()));
+    expect(trace.segmentCount).toBe(1);
+    expect(trace.generations).toHaveLength(2);
+
+    const [first, second] = trace.generations;
+    expect(first!.carriedMessages).toBe(0);
+    // the step's own response rides in its snapshot; next step carries it all
+    expect(second!.carriedMessages).toBe(4);
+
+    const call = first!.newMessages.find((m) => m.toolCalls)?.toolCalls?.[0];
+    expect(call?.name).toBe("getWeather");
+    expect(call?.result).toContain("tempC");
+    // paired results fold under their call instead of rendering as messages
+    expect(first!.foldedResults).toBe(1);
+  });
+
+  it("splits reasoning out of assistant text", () => {
+    const trace = normalizeTrace(aiSdkDevtoolsAdapter.adapt(twoStepDb()));
+    const assistant = trace.generations[0]!.newMessages.at(-1)!;
+    expect(assistant.reasoning).toBe("Need the tool.");
+    expect(assistant.text).not.toContain("Need the tool.");
+  });
+
+  it("maps usage: totals, cache reads, reasoning tokens", () => {
+    const trace = normalizeTrace(aiSdkDevtoolsAdapter.adapt(twoStepDb()));
+    const [first, second] = trace.generations;
+    expect(first!.metrics.inputTokens).toBe(100);
+    expect(first!.metrics.reasoningTokens).toBe(5);
+    expect(second!.metrics.inputTokens).toBe(130);
+    expect(second!.breakdown.cacheableTokens).toBe(100);
+  });
+
+  it("handles legacy and provider-level usage shapes", () => {
+    const legacy = normalizeTrace(
+      aiSdkDevtoolsAdapter.adapt({
+        runs: [run("r1")],
+        steps: [step({ usage: { inputTokens: 50, outputTokens: 5, cachedInputTokens: 30 } })],
+      }),
+    );
+    expect(legacy.generations[0]!.metrics.inputTokens).toBe(50);
+    expect(legacy.generations[0]!.breakdown.cacheableTokens).toBe(30);
+
+    const v4 = normalizeTrace(
+      aiSdkDevtoolsAdapter.adapt({
+        runs: [run("r1")],
+        steps: [
+          step({
+            usage: {
+              inputTokens: { total: 70, cacheRead: 40 },
+              outputTokens: { total: 7, reasoning: 2 },
+            },
+          }),
+        ],
+      }),
+    );
+    expect(v4.generations[0]!.metrics.inputTokens).toBe(70);
+    expect(v4.generations[0]!.metrics.reasoningTokens).toBe(2);
+  });
+
+  it("reconstructs middleware-shaped outputs (parts + stringified args)", () => {
+    const trace = normalizeTrace(
+      aiSdkDevtoolsAdapter.adapt({
+        runs: [run("r1")],
+        steps: [
+          step({
+            output: {
+              textParts: [{ text: "partial" }],
+              toolCalls: [
+                { type: "tool-call", toolCallId: "c1", toolName: "grep", input: '{"q":"x"}' },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+    const assistant = trace.generations[0]!.newMessages.at(-1)!;
+    expect(assistant.text).toBe("partial");
+    expect(assistant.toolCalls?.[0]?.args).toEqual({ q: "x" });
+  });
+
+  it("marks in-flight steps and errored steps", () => {
+    const trace = normalizeTrace(
+      aiSdkDevtoolsAdapter.adapt({
+        runs: [run("r1")],
+        steps: [
+          step({ step_number: 1, duration_ms: null, output: null, usage: null }),
+          step({ step_number: 2, error: "boom", output: null, usage: null }),
+        ],
+      }),
+    );
+    expect(trace.inProgress).toBe(true);
+    expect(trace.generations[0]!.inProgress).toBe(true);
+    expect(trace.generations[1]!.inProgress).toBeUndefined();
+    expect(trace.generations[1]!.newMessages.at(-1)!.text).toContain("[error] boom");
+  });
+});
+
+describe("split", () => {
+  it("emits one part per run, children right after their parent", () => {
+    const parts = aiSdkDevtoolsAdapter.split!({
+      runs: [
+        run("a"),
+        run("b"),
+        run("a-child", { parent_run_id: "a", parent_step_id: "step-a-1" }),
+      ],
+      steps: [step({ run_id: "a" }), step({ run_id: "b" }), step({ run_id: "a-child" })],
+    });
+    expect(parts.map((p) => p.runs[0]!.id)).toEqual(["a", "a-child", "b"]);
+    for (const part of parts) {
+      expect(part.steps.every((s) => s.run_id === part.runs[0]!.id)).toBe(true);
+    }
+  });
+
+  it("treats a run with an unknown parent as a root", () => {
+    const parts = aiSdkDevtoolsAdapter.split!({
+      runs: [run("orphan", { parent_run_id: "gone" })],
+      steps: [step({ run_id: "orphan" })],
+    });
+    expect(parts).toHaveLength(1);
+  });
+
+  it("records lineage on child parts", () => {
+    const [child] = aiSdkDevtoolsAdapter.split!({
+      runs: [run("child", { parent_run_id: "parent" })],
+      steps: [step({ run_id: "child" })],
+    }).map((part) => aiSdkDevtoolsAdapter.adapt(part));
+    expect(child!.parent_trace_id).toBe("parent");
+  });
+
+  it("returns no parts for an empty database", () => {
+    expect(aiSdkDevtoolsAdapter.split!({ runs: [], steps: [] })).toEqual([]);
+  });
+});
+
+describe("trace naming", () => {
+  it("labels a run by its last user message, collapsed and capped", () => {
+    const raw = aiSdkDevtoolsAdapter.adapt({
+      runs: [run("r1")],
+      steps: [
+        step({
+          input: { prompt: [{ role: "user", content: `##  Title\n\n${"x".repeat(100)}` }] },
+        }),
+      ],
+    });
+    expect(raw.name.startsWith("## Title x")).toBe(true);
+    expect(raw.name.length).toBeLessThanOrEqual(83);
+  });
+
+  it("prefers function_id and falls back for merged databases", () => {
+    const named = aiSdkDevtoolsAdapter.adapt({
+      runs: [run("r1", { function_id: "qa-agent" })],
+      steps: [step({})],
+    });
+    expect(named.name).toBe("qa-agent");
+
+    const merged = aiSdkDevtoolsAdapter.adapt({
+      runs: [run("a"), run("b")],
+      steps: [step({ run_id: "a" }), step({ run_id: "b" })],
+    });
+    expect(merged.name).toBe("AI SDK devtools session");
+  });
+});

--- a/src/core/adapters/gateway.ts
+++ b/src/core/adapters/gateway.ts
@@ -9,9 +9,7 @@ import type { TraceAdapter } from "./adapter";
 export const gatewayAdapter: TraceAdapter<RawTrace> = {
   name: "gateway",
   detect(json: unknown): json is RawTrace {
-    return (
-      typeof json === "object" && json !== null && Array.isArray((json as RawTrace).events)
-    );
+    return typeof json === "object" && json !== null && Array.isArray((json as RawTrace).events);
   },
   adapt(json: RawTrace): RawTrace {
     assertTraceShape(json);

--- a/src/core/adapters/opencode.ts
+++ b/src/core/adapters/opencode.ts
@@ -87,8 +87,7 @@ function adaptOpencodeTrace(oc: OpencodeExport): RawTrace {
     // model time excludes tool execution, which the message duration includes
     const toolSeconds =
       message.parts.reduce((acc, p) => acc + (p.type === "tool" ? (toolMs(p) ?? 0) : 0), 0) / 1000;
-    const duration =
-      Math.max(messageSeconds(message) - toolSeconds, 0) / Math.max(steps.length, 1);
+    const duration = Math.max(messageSeconds(message) - toolSeconds, 0) / Math.max(steps.length, 1);
     for (const step of steps) {
       const finish = step.find((p) => p.type === "step-finish");
       const tools = step.filter((p) => p.type === "tool");

--- a/src/core/collection.test.ts
+++ b/src/core/collection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { parseCollection, runSummaries } from "./collection";
+import { normalizeTrace } from "./normalize";
+import type { RawTrace } from "./types";
+
+const GATEWAY = {
+  trace_id: "g1",
+  timestamp: "2026-08-25T10:00:00.000Z",
+  name: "gateway trace",
+  total_tokens: { input: 1, output: 1 },
+  total_cost: 0.1,
+  events: [
+    {
+      type: "generation",
+      name: "agent",
+      model: "m",
+      provider: "p",
+      metrics: { latency: 1, tokens: { input: 1, output: 1 }, cost: 0.1 },
+      messages: [{ role: "user", content: "hi" }],
+    },
+  ],
+};
+
+describe("parseCollection", () => {
+  it("wraps single-trace formats in a one-item collection", () => {
+    const collection = parseCollection(GATEWAY);
+    expect(collection.format).toBe("gateway");
+    expect(collection.items).toHaveLength(1);
+    expect(collection.items[0]!.trace.traceId).toBe("g1");
+  });
+
+  it("throws a readable error for unknown formats", () => {
+    expect(() => parseCollection({ nonsense: true })).toThrow(/Known formats/);
+  });
+});
+
+describe("runSummaries", () => {
+  function item(id: string, parent?: string) {
+    const raw: RawTrace = {
+      trace_id: id,
+      timestamp: "2026-08-25T10:00:00.000Z",
+      name: id,
+      total_tokens: { input: 0, output: 0 },
+      total_cost: 0,
+      ...(parent !== undefined ? { parent_trace_id: parent } : {}),
+      events: [],
+    };
+    return { raw, trace: normalizeTrace(raw) };
+  }
+
+  it("computes nesting depth from lineage within the collection", () => {
+    const summaries = runSummaries([
+      item("root"),
+      item("child", "root"),
+      item("grandchild", "child"),
+      item("stray", "not-here"),
+    ]);
+    expect(summaries.map((s) => [s.id, s.depth])).toEqual([
+      ["root", 0],
+      ["child", 1],
+      ["grandchild", 2],
+      // an ancestor outside the collection contributes no depth
+      ["stray", 0],
+    ]);
+  });
+
+  it("survives lineage cycles", () => {
+    const a = item("a", "b");
+    const b = item("b", "a");
+    expect(() => runSummaries([a, b])).not.toThrow();
+  });
+});

--- a/src/core/normalize.test.ts
+++ b/src/core/normalize.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTrace } from "./normalize";
+import type { RawEvent, RawMessage, RawTrace } from "./types";
+
+function trace(events: RawEvent[], overrides: Partial<RawTrace> = {}): RawTrace {
+  return {
+    trace_id: "t1",
+    timestamp: "2026-08-25T10:00:00.000Z",
+    name: "test",
+    total_tokens: { input: 0, output: 0 },
+    total_cost: 0,
+    events,
+    ...overrides,
+  };
+}
+
+function event(messages: RawMessage[], overrides: Partial<RawEvent> = {}): RawEvent {
+  return {
+    type: "generation",
+    name: "agent",
+    model: "m",
+    provider: "p",
+    metrics: { latency: 1, tokens: { input: 100, output: 10 }, cost: 0 },
+    messages,
+    ...overrides,
+  };
+}
+
+const SYS: RawMessage = { role: "system", content: "sys prompt" };
+const USER: RawMessage = { role: "user", content: "hello" };
+
+describe("segments", () => {
+  it("joins continuations and splits resets", () => {
+    const reply: RawMessage = { role: "assistant", content: "hi" };
+    const normalized = normalizeTrace(
+      trace([
+        event([SYS, USER]),
+        event([SYS, USER, reply, { role: "user", content: "more" }]),
+        event([{ role: "user", content: "fresh conversation" }]),
+      ]),
+    );
+    expect(normalized.segmentCount).toBe(2);
+    expect(normalized.generations.map((g) => g.segment)).toEqual([0, 0, 1]);
+    expect(normalized.generations[1]!.carriedMessages).toBe(2);
+  });
+});
+
+describe("tool pairing", () => {
+  const call: RawMessage = {
+    role: "assistant",
+    content: "",
+    tool_calls: [{ type: "function", id: "c1", function: { name: "grep", arguments: {} } }],
+  };
+  const result: RawMessage = { role: "tool", content: "match found", tool_call_id: "c1" };
+
+  it("pairs a result from the next snapshot and fills late args", () => {
+    const callWithArgs: RawMessage = {
+      ...call,
+      tool_calls: [
+        { type: "function", id: "c1", function: { name: "grep", arguments: { q: "x" } } },
+      ],
+    };
+    const normalized = normalizeTrace(
+      trace([event([USER, call]), event([USER, callWithArgs, result])]),
+    );
+    const paired = normalized.generations[0]!.newMessages.at(-1)!.toolCalls![0]!;
+    expect(paired.result).toBe("match found");
+    // streaming snapshots capture the newest call with empty args
+    expect(paired.args).toEqual({ q: "x" });
+    // the result message folds under the call in the later generation
+    expect(normalized.generations[1]!.foldedResults).toBe(1);
+  });
+});
+
+describe("reasoning", () => {
+  it("splits reasoning parts out of the text", () => {
+    const normalized = normalizeTrace(
+      trace([
+        event([
+          {
+            role: "assistant",
+            content: [
+              { type: "reasoning", text: "think first" },
+              { type: "text", text: "answer" },
+            ],
+          },
+        ]),
+      ]),
+    );
+    const message = normalized.generations[0]!.newMessages[0]!;
+    expect(message.reasoning).toBe("think first");
+    expect(message.text).toBe("answer");
+  });
+
+  it("keeps withheld reasoning visible as an empty string", () => {
+    const normalized = normalizeTrace(
+      trace([event([{ role: "assistant", content: [{ type: "reasoning", text: "" }] }])]),
+    );
+    expect(normalized.generations[0]!.newMessages[0]!.reasoning).toBe("");
+  });
+
+  it("leaves plain content untouched", () => {
+    const normalized = normalizeTrace(trace([event([USER])]));
+    expect(normalized.generations[0]!.newMessages[0]!.reasoning).toBeUndefined();
+  });
+});
+
+describe("cache attribution", () => {
+  it("prefers reported cache reads, clamped to the request's input", () => {
+    const normalized = normalizeTrace(
+      trace([
+        event([SYS, USER], {
+          metrics: { latency: 1, tokens: { input: 100, output: 10, cache_read: 250 }, cost: 0 },
+        }),
+      ]),
+    );
+    expect(normalized.generations[0]!.breakdown.cacheableTokens).toBe(100);
+  });
+
+  it("infers the predecessor's input on an unmutated continuation", () => {
+    const reply: RawMessage = { role: "assistant", content: "hi" };
+    const normalized = normalizeTrace(
+      trace([
+        event([SYS, USER]),
+        event([SYS, USER, reply], {
+          metrics: { latency: 1, tokens: { input: 140, output: 10 }, cost: 0 },
+        }),
+      ]),
+    );
+    expect(normalized.generations[1]!.breakdown.cacheableTokens).toBe(100);
+  });
+});
+
+describe("in-flight generations", () => {
+  it("passes flags through and keeps char-based estimates at zero input", () => {
+    const normalized = normalizeTrace(
+      trace(
+        [
+          event([SYS, USER], {
+            in_progress: true,
+            metrics: { latency: 0, tokens: { input: 0, output: 0 }, cost: 0 },
+          }),
+        ],
+        { in_progress: true },
+      ),
+    );
+    expect(normalized.inProgress).toBe(true);
+    const generation = normalized.generations[0]!;
+    expect(generation.inProgress).toBe(true);
+    const estimated = generation.breakdown.groups.flatMap((g) => g.items).map((i) => i.estTokens);
+    expect(Math.max(...estimated)).toBeGreaterThan(0);
+  });
+});
+
+describe("shape validation", () => {
+  it("rejects events without messages or metrics", () => {
+    expect(() => normalizeTrace(trace([{ metrics: {} } as unknown as RawEvent]))).toThrow(
+      /messages/,
+    );
+  });
+});

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -68,9 +68,7 @@ export function assertTraceShape(raw: unknown): asserts raw is RawTrace {
       typeof m.latency !== "number" ||
       typeof m.cost !== "number"
     ) {
-      throw new Error(
-        `Unsupported trace: events[${i}] is missing metrics (latency, tokens, cost)`,
-      );
+      throw new Error(`Unsupported trace: events[${i}] is missing metrics (latency, tokens, cost)`);
     }
   }
 }
@@ -115,9 +113,7 @@ function assignSegments(events: RawEvent[]): EventPosition[] {
         break;
       }
     }
-    positions.push(
-      found ?? { segment: segments++, carried: 0, prevIndex: null, firstMutation: 0 },
-    );
+    positions.push(found ?? { segment: segments++, carried: 0, prevIndex: null, firstMutation: 0 });
   });
   return positions;
 }
@@ -141,7 +137,10 @@ function continuationOf(prev: RawMessage[], next: RawMessage[]): number | null {
     const structurallySame =
       a.role === b.role &&
       a.tool_call_id === b.tool_call_id &&
-      deepEqual(a.tool_calls?.map((c) => c.id), b.tool_calls?.map((c) => c.id));
+      deepEqual(
+        a.tool_calls?.map((c) => c.id),
+        b.tool_calls?.map((c) => c.id),
+      );
     if (structurallySame && isCompacted(b)) {
       firstMutation = Math.min(firstMutation, k);
       continue;
@@ -161,7 +160,10 @@ function argsFilledIn(a: RawMessage, b: RawMessage): boolean {
   return callsA.every((call, i) => {
     const other = callsB[i]!;
     if (call.id !== other.id || call.function.name !== other.function.name) return false;
-    return deepEqual(call.function.arguments, other.function.arguments) || isEmptyArgs(call.function.arguments);
+    return (
+      deepEqual(call.function.arguments, other.function.arguments) ||
+      isEmptyArgs(call.function.arguments)
+    );
   });
 }
 
@@ -188,11 +190,11 @@ export function toolCallNames(gen: Generation): string[] {
 }
 
 /** Every tool call in the trace, in order, tagged with its generation index. */
-export function allToolCalls(
-  trace: NormalizedTrace,
-): (PairedToolCall & { gen: number })[] {
+export function allToolCalls(trace: NormalizedTrace): (PairedToolCall & { gen: number })[] {
   return trace.generations.flatMap((gen) =>
-    gen.newMessages.flatMap((m) => (m.toolCalls ?? []).map((call) => ({ ...call, gen: gen.index }))),
+    gen.newMessages.flatMap((m) =>
+      (m.toolCalls ?? []).map((call) => ({ ...call, gen: gen.index })),
+    ),
   );
 }
 
@@ -246,7 +248,9 @@ function normalizeEvent(
     .slice(carried)
     .map((message, offset) => ({ raw: message, index: carried + offset }))
     // paired results render inline under their call; orphans stay visible
-    .filter(({ raw }) => !(isToolResult(raw) && pairing.callIds.has(`${segment}:${raw.tool_call_id}`)))
+    .filter(
+      ({ raw }) => !(isToolResult(raw) && pairing.callIds.has(`${segment}:${raw.tool_call_id}`)),
+    )
     .map(({ raw, index }) => normalizeMessage(raw, index, segment, pairing));
 
   return {
@@ -464,8 +468,7 @@ function attachmentLabel(part: {
 }): string | undefined {
   if (part?.type !== "file" && part?.type !== "image") return undefined;
   const media = typeof part.mediaType === "string" ? part.mediaType : "unknown type";
-  const stub =
-    typeof part.file === "string" && part.file.length < 100 ? ` (${part.file})` : "";
+  const stub = typeof part.file === "string" && part.file.length < 100 ? ` (${part.file})` : "";
   return `[attachment: ${media}${stub} - bytes not included in the trace export]`;
 }
 
@@ -593,7 +596,8 @@ function preview(message: RawMessage): string {
   const text = contentToText(message.content);
   if (text) return text.slice(0, 280);
   const call = message.tool_calls?.[0];
-  if (call) return `${call.function.name}(${JSON.stringify(call.function.arguments ?? {})})`.slice(0, 280);
+  if (call)
+    return `${call.function.name}(${JSON.stringify(call.function.arguments ?? {})})`.slice(0, 280);
   return "";
 }
 

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useRef, useState } from "react";
 import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
+import { useEffect, useRef, useState } from "react";
 import { GenerationDetail } from "@/components/GenerationDetail";
-import { CopyButton } from "@/components/ui/copy-button";
 import { Header } from "@/components/Header";
 import { ReplayBar } from "@/components/ReplayBar";
 import { RunList } from "@/components/RunList";
 import { ToolCallsSection } from "@/components/ToolCallsSection";
 import { TreemapSection } from "@/components/TreemapSection";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Waterfall } from "@/components/Waterfall";
 import { useReplay } from "@/lib/use-replay";
 import { useTrace } from "@/lib/use-trace";
@@ -96,7 +96,9 @@ function Loaded({
   if (!selected) {
     return (
       <Shell>
-        {live ? <WaitingForCalls /> : (
+        {live ? (
+          <WaitingForCalls />
+        ) : (
           <p className="type-body-m p-8 text-ta-error">Trace has no generations.</p>
         )}
       </Shell>
@@ -122,11 +124,7 @@ function Loaded({
           {runs.length > 1 && (
             <RunList runs={runs} selectedId={selectedRun} onSelect={onSelectRun} />
           )}
-          <Waterfall
-            trace={trace}
-            selectedIndex={selected.index}
-            onSelect={selectGeneration}
-          />
+          <Waterfall trace={trace} selectedIndex={selected.index} onSelect={selectGeneration} />
         </aside>
         <main className="flex min-w-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]">
           {/* context + timeline fill exactly the first viewport; the rest scrolls in */}
@@ -182,7 +180,15 @@ function WaitingForCalls() {
   );
 }
 
-function SetupStep({ n, label, children }: { n: number; label: string; children: React.ReactNode }) {
+function SetupStep({
+  n,
+  label,
+  children,
+}: {
+  n: number;
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex flex-col gap-2">
       <p className="type-accent-s text-ta-grey-200">

--- a/src/viewer/components/CallDialog.tsx
+++ b/src/viewer/components/CallDialog.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
-import type { PairedToolCall } from "@core/types";
 import { formatMs } from "@core/format";
+import { prettyArgs, prettyPayload } from "@core/pretty";
+import type { PairedToolCall } from "@core/types";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { prettyArgs, prettyPayload } from "@core/pretty";
 
 interface CallDialogProps {
   call: PairedToolCall;

--- a/src/viewer/components/DefinitionDialog.tsx
+++ b/src/viewer/components/DefinitionDialog.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
 import { contentToText } from "@core/normalize";
+import { prettyArgs, prettyPayload } from "@core/pretty";
 import type { RawMessage, RawToolDef } from "@core/types";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Markdown } from "@/components/ui/markdown";
-import { prettyArgs, prettyPayload } from "@core/pretty";
 import type { TreemapLeaf } from "@/lib/treemap-data";
 
 /** Full definition of a clicked treemap block: pretty-rendered, raw JSON a toggle away. */
@@ -131,9 +131,12 @@ function MessageDefinition({ message }: { message: RawMessage }) {
   const text = prettyPayload(contentToText(message.content));
   return (
     <div className="flex flex-col gap-5">
-      {text && (looksLikeMarkdown(text) ? <Markdown>{text}</Markdown> : (
-        <p className="type-body-m whitespace-pre-wrap text-ta-grey-100">{text}</p>
-      ))}
+      {text &&
+        (looksLikeMarkdown(text) ? (
+          <Markdown>{text}</Markdown>
+        ) : (
+          <p className="type-body-m whitespace-pre-wrap text-ta-grey-100">{text}</p>
+        ))}
       {message.tool_calls?.map((call) => (
         <div key={call.id} className="border border-ta-grey-400 bg-ta-grey-450 px-4 py-3">
           <p className="type-accent-s text-ta-orange-75">{call.function.name}</p>

--- a/src/viewer/components/GenerationDetail.tsx
+++ b/src/viewer/components/GenerationDetail.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import type { Generation, NormalizedTrace } from "@core/types";
 import { formatCost, formatPercent, formatSeconds, formatTokens } from "@core/format";
+import type { Generation, NormalizedTrace } from "@core/types";
+import { useState } from "react";
 import { MessageCard } from "@/components/MessageCard";
 import { Button } from "@/components/ui/button";
 import { Hint } from "@/components/ui/hint";
@@ -28,9 +28,8 @@ export function GenerationDetail({ trace, generation }: GenerationDetailProps) {
       meta={
         <>
           {generation.model} · {formatTokens(m.inputTokens)} in / {formatTokens(m.outputTokens)}
-          {m.reasoningTokens !== undefined &&
-            ` (${formatTokens(m.reasoningTokens)} reasoning)`}{" "}
-          out ·{" "}
+          {m.reasoningTokens !== undefined && ` (${formatTokens(m.reasoningTokens)} reasoning)`} out
+          ·{" "}
           {generation.inProgress ? (
             <span className="text-ta-orange-300">streaming...</span>
           ) : (
@@ -42,47 +41,48 @@ export function GenerationDetail({ trace, generation }: GenerationDetailProps) {
       }
     >
       <div className="flex flex-col gap-3 px-6 pb-4">
-      <p className="type-accent-s text-ta-grey-200">
-        {generation.carriedMessages > 0
-          ? `${generation.carriedMessages} carried messages, showing the ${generation.newMessages.length} new`
-          : `fresh conversation (segment ${generation.segment}), ${generation.newMessages.length} messages`}
-        {generation.breakdown.cacheableTokens > 0 && (
-          <>
-            {" · "}
-            {formatPercent(generation.breakdown.cacheableTokens, generation.metrics.inputTokens)}{" "}
-            <Hint term="repeated prefix">repeated prefix</Hint>
-          </>
+        <p className="type-accent-s text-ta-grey-200">
+          {generation.carriedMessages > 0
+            ? `${generation.carriedMessages} carried messages, showing the ${generation.newMessages.length} new`
+            : `fresh conversation (segment ${generation.segment}), ${generation.newMessages.length} messages`}
+          {generation.breakdown.cacheableTokens > 0 && (
+            <>
+              {" · "}
+              {formatPercent(generation.breakdown.cacheableTokens, generation.metrics.inputTokens)}{" "}
+              <Hint term="repeated prefix">repeated prefix</Hint>
+            </>
+          )}
+          {generation.metrics.timeToFirstToken !== undefined && (
+            <>
+              {" · "}
+              <Hint term="prompt wait">prompt wait</Hint>{" "}
+              {formatPercent(generation.metrics.timeToFirstToken, generation.metrics.latency)} of
+              latency
+            </>
+          )}
+        </p>
+        {generation.carriedMessages > 0 && (
+          <Button className="self-start" onClick={() => setShowCarried((v) => !v)}>
+            {showCarried
+              ? "hide carried context"
+              : `show carried context (${generation.carriedMessages} messages)`}
+          </Button>
         )}
-        {generation.metrics.timeToFirstToken !== undefined && (
-          <>
-            {" · "}
-            <Hint term="prompt wait">prompt wait</Hint>{" "}
-            {formatPercent(generation.metrics.timeToFirstToken, generation.metrics.latency)} of latency
-          </>
+        {showCarried && (
+          <div className="flex flex-col gap-2 opacity-60">
+            {carried.map((message) => (
+              <MessageCard key={`carried-${message.index}`} message={message} />
+            ))}
+          </div>
         )}
-      </p>
-      {generation.carriedMessages > 0 && (
-        <Button className="self-start" onClick={() => setShowCarried((v) => !v)}>
-          {showCarried
-            ? "hide carried context"
-            : `show carried context (${generation.carriedMessages} messages)`}
-        </Button>
-      )}
-      {showCarried && (
-        <div className="flex flex-col gap-2 opacity-60">
-          {carried.map((message) => (
-            <MessageCard key={`carried-${message.index}`} message={message} />
+        {showCarried && carried.length > 0 && (
+          <p className="type-accent-s text-ta-grey-200">new in this generation ↓</p>
+        )}
+        <div className="flex flex-col gap-2">
+          {generation.newMessages.map((message) => (
+            <MessageCard key={message.index} message={message} />
           ))}
         </div>
-      )}
-      {showCarried && carried.length > 0 && (
-        <p className="type-accent-s text-ta-grey-200">new in this generation ↓</p>
-      )}
-      <div className="flex flex-col gap-2">
-        {generation.newMessages.map((message) => (
-          <MessageCard key={message.index} message={message} />
-        ))}
-      </div>
       </div>
     </Section>
   );

--- a/src/viewer/components/Header.tsx
+++ b/src/viewer/components/Header.tsx
@@ -1,5 +1,5 @@
-import type { NormalizedTrace } from "@core/types";
 import { formatCost, formatSeconds, formatTokens } from "@core/format";
+import type { NormalizedTrace } from "@core/types";
 import { Button } from "@/components/ui/button";
 import { Hint } from "@/components/ui/hint";
 
@@ -16,11 +16,17 @@ export function Header({ trace, onClear }: HeaderProps) {
       <span className="type-body-m min-w-0 truncate text-ta-sand-50">{trace.name}</span>
       <span className="type-accent-s text-ta-grey-200">{trace.models.join(", ")}</span>
       <div className="type-accent-s ml-auto flex shrink-0 items-baseline gap-6 text-ta-grey-100">
-        <Stat label={<Hint term="generation">generations</Hint>} value={String(trace.generations.length)} />
+        <Stat
+          label={<Hint term="generation">generations</Hint>}
+          value={String(trace.generations.length)}
+        />
         <Stat label={<Hint term="segment">segments</Hint>} value={String(trace.segmentCount)} />
         <Stat label="in" value={formatTokens(trace.totalTokens.input)} />
         <Stat label="out" value={formatTokens(trace.totalTokens.output)} />
-        <Stat label={<Hint term="model time">model time</Hint>} value={formatSeconds(trace.totalLatency)} />
+        <Stat
+          label={<Hint term="model time">model time</Hint>}
+          value={formatSeconds(trace.totalLatency)}
+        />
         {/* traces without price data report 0 - a real run never costs exactly $0 */}
         {trace.totalCost > 0 && <Stat label="cost" value={formatCost(trace.totalCost)} />}
         {onClear && <Button onClick={onClear}>clear</Button>}

--- a/src/viewer/components/MessageCard.tsx
+++ b/src/viewer/components/MessageCard.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import type { Message, MessageRole } from "@core/types";
 import { formatCompact, formatTokens } from "@core/format";
+import { prettyArgs, prettyPayload } from "@core/pretty";
+import type { Message, MessageRole } from "@core/types";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
-import { prettyArgs, prettyPayload } from "@core/pretty";
 import { cn } from "@/lib/utils";
 
 const COLLAPSED_CHARS = 700;
@@ -74,21 +74,22 @@ function Thinking({ reasoning }: { reasoning: string }) {
   const [open, setOpen] = useState(false);
   if (!reasoning) {
     return (
-      <p className="type-accent-s mb-2 text-ta-grey-200">
-        thinking · content withheld by provider
-      </p>
+      <p className="type-accent-s mb-2 text-ta-grey-200">thinking · content withheld by provider</p>
     );
   }
   const overflows = reasoning.length > THINKING_PREVIEW_CHARS;
   return (
     <div className="mb-2 border border-ta-grey-400 bg-ta-grey-500 px-3 py-2">
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         className="type-accent-s flex w-full cursor-pointer items-center gap-2 text-left text-ta-sand-300"
       >
         <span>{open ? "▾" : "▸"} thinking</span>
-        <span className="text-ta-grey-200">~{formatTokens(Math.round(reasoning.length / 4))} tok</span>
+        <span className="text-ta-grey-200">
+          ~{formatTokens(Math.round(reasoning.length / 4))} tok
+        </span>
       </button>
       <p
         className={cn(

--- a/src/viewer/components/ReplayBar.tsx
+++ b/src/viewer/components/ReplayBar.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef, useState } from "react";
-import type { NormalizedTrace } from "@core/types";
 import { formatPercent, formatSeconds } from "@core/format";
+import type { NormalizedTrace } from "@core/types";
+import { useEffect, useRef, useState } from "react";
 import { TimelineList } from "@/components/TimelineList";
 import { Button } from "@/components/ui/button";
 import { Hint } from "@/components/ui/hint";
 import { Section } from "@/components/ui/section";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { SPEEDS, type Replay } from "@/lib/use-replay";
+import { type Replay, SPEEDS } from "@/lib/use-replay";
 import { cn } from "@/lib/utils";
 
 interface ReplayBarProps {
@@ -68,10 +68,7 @@ export function ReplayBar({ trace, replay, selectedIndex, onSelect }: ReplayBarP
     >
       <div
         ref={playerRef}
-        className={cn(
-          "flex min-h-0 flex-1 flex-col px-6 pb-4",
-          fullscreen && "bg-ta-grey-500 p-4",
-        )}
+        className={cn("flex min-h-0 flex-1 flex-col px-6 pb-4", fullscreen && "bg-ta-grey-500 p-4")}
       >
         {total <= 0 ? (
           <p className="type-accent-s border border-ta-grey-400 px-3 py-2 text-ta-grey-200">
@@ -96,7 +93,12 @@ export function ReplayBar({ trace, replay, selectedIndex, onSelect }: ReplayBarP
                 onSelect={onSelect}
               />
             )}
-            <PlayerControls replay={replay} onScrub={scrub} playerRef={playerRef} fullscreen={fullscreen} />
+            <PlayerControls
+              replay={replay}
+              onScrub={scrub}
+              playerRef={playerRef}
+              fullscreen={fullscreen}
+            />
           </>
         )}
       </div>
@@ -227,6 +229,7 @@ function Lanes({ trace, replay, selectedIndex, onSelect }: ReplayBarProps) {
           const lane = lanes.indexOf(gen.name);
           return (
             <button
+              type="button"
               key={gen.index}
               onClick={() => onSelect(gen.index)}
               aria-pressed={selected}

--- a/src/viewer/components/RunList.tsx
+++ b/src/viewer/components/RunList.tsx
@@ -12,56 +12,54 @@ interface RunListProps {
 export function RunList({ runs, selectedId, onSelect }: RunListProps) {
   return (
     <div className="border-b border-ta-grey-400 pb-3">
-      <p className="type-accent-s mb-1 mt-4 px-4 text-ta-grey-200">
-        runs · {runs.length}
-      </p>
-      {newestFirstTrees(runs)
-        .map(({ run, number }) => {
-          const selected = run.id === selectedId;
-          return (
-            <button
-              key={run.id}
-              onClick={() => onSelect(run.id)}
-              aria-pressed={selected}
-              title={`${formatTokens(run.totalTokens.input)} in / ${formatTokens(run.totalTokens.output)} out · ${run.models.join(", ")} · ${new Date(run.timestamp).toLocaleTimeString()}`}
+      <p className="type-accent-s mb-1 mt-4 px-4 text-ta-grey-200">runs · {runs.length}</p>
+      {newestFirstTrees(runs).map(({ run, number }) => {
+        const selected = run.id === selectedId;
+        return (
+          <button
+            type="button"
+            key={run.id}
+            onClick={() => onSelect(run.id)}
+            aria-pressed={selected}
+            title={`${formatTokens(run.totalTokens.input)} in / ${formatTokens(run.totalTokens.output)} out · ${run.models.join(", ")} · ${new Date(run.timestamp).toLocaleTimeString()}`}
+            className={cn(
+              "type-accent-s flex w-full cursor-pointer items-center gap-3 px-4 py-1.5 text-left transition-colors hover:bg-ta-grey-450",
+              selected && "bg-ta-grey-300/25",
+            )}
+          >
+            <span
               className={cn(
-                "type-accent-s flex w-full cursor-pointer items-center gap-3 px-4 py-1.5 text-left transition-colors hover:bg-ta-grey-450",
-                selected && "bg-ta-grey-300/25",
+                "w-5 shrink-0 text-right",
+                selected ? "text-ta-orange-300" : "text-ta-grey-300",
               )}
             >
-              <span
-                className={cn(
-                  "w-5 shrink-0 text-right",
-                  selected ? "text-ta-orange-300" : "text-ta-grey-300",
-                )}
-              >
-                {number}
-              </span>
-              <span
-                className={cn(
-                  "min-w-0 flex-1 truncate",
-                  selected ? "text-ta-sand-50" : "text-ta-grey-100",
-                )}
-                style={run.depth > 0 ? { paddingLeft: run.depth * 12 } : undefined}
-              >
-                {run.depth > 0 && <span className="text-ta-grey-300">↳ </span>}
-                {run.name}
-              </span>
-              <span
-                className={cn(
-                  "shrink-0",
-                  run.inProgress
-                    ? "text-ta-orange-300"
-                    : selected
-                      ? "text-ta-sand-50"
-                      : "text-ta-grey-200",
-                )}
-              >
-                {run.inProgress ? "live" : `${run.generations} gen`}
-              </span>
-            </button>
-          );
-        })}
+              {number}
+            </span>
+            <span
+              className={cn(
+                "min-w-0 flex-1 truncate",
+                selected ? "text-ta-sand-50" : "text-ta-grey-100",
+              )}
+              style={run.depth > 0 ? { paddingLeft: run.depth * 12 } : undefined}
+            >
+              {run.depth > 0 && <span className="text-ta-grey-300">↳ </span>}
+              {run.name}
+            </span>
+            <span
+              className={cn(
+                "shrink-0",
+                run.inProgress
+                  ? "text-ta-orange-300"
+                  : selected
+                    ? "text-ta-sand-50"
+                    : "text-ta-grey-200",
+              )}
+            >
+              {run.inProgress ? "live" : `${run.generations} gen`}
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/viewer/components/TimelineList.tsx
+++ b/src/viewer/components/TimelineList.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { NormalizedTrace, PairedToolCall } from "@core/types";
 import { formatCost, formatMs, formatSeconds, formatTokens } from "@core/format";
+import type { NormalizedTrace, PairedToolCall } from "@core/types";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CallDialog } from "@/components/CallDialog";
 import type { Replay } from "@/lib/use-replay";
 import { cn } from "@/lib/utils";
@@ -197,7 +197,11 @@ export function TimelineList({
               setOverTool(key !== null && callsByKey.has(key));
               return;
             }
-            if (!down.moved && Math.abs(e.clientX - down.x) < 4 && Math.abs(e.clientY - down.y) < 4) {
+            if (
+              !down.moved &&
+              Math.abs(e.clientX - down.x) < 4 &&
+              Math.abs(e.clientY - down.y) < 4
+            ) {
               return;
             }
             down.moved = true;
@@ -233,7 +237,11 @@ export function TimelineList({
           </span>
           <span className="relative min-w-0 flex-1">
             {ticks.map((t) => (
-              <span key={t} className="absolute translate-x-1.5" style={{ left: `${(t / total) * 100}%` }}>
+              <span
+                key={t}
+                className="absolute translate-x-1.5"
+                style={{ left: `${(t / total) * 100}%` }}
+              >
                 {formatSeconds(t)}
               </span>
             ))}
@@ -254,6 +262,7 @@ export function TimelineList({
           const isTool = row.kind === "tool";
           return (
             <button
+              type="button"
               key={row.key}
               ref={!isTool && selected ? selectedRef : undefined}
               onClick={() => {

--- a/src/viewer/components/ToolCallsSection.tsx
+++ b/src/viewer/components/ToolCallsSection.tsx
@@ -1,11 +1,12 @@
-import { Fragment, useMemo, useState } from "react";
-import type { NormalizedTrace, PairedToolCall } from "@core/types";
-import { allToolCalls } from "@core/normalize";
 import { formatCompact, formatMs } from "@core/format";
+import { allToolCalls } from "@core/normalize";
+import type { NormalizedTrace, PairedToolCall } from "@core/types";
+import { Fragment, useMemo, useState } from "react";
 import { Section } from "@/components/ui/section";
 import { cn } from "@/lib/utils";
 
-const GRID = "grid grid-cols-[minmax(9rem,1fr)_4rem_4rem_5rem_5rem_minmax(6rem,1.5fr)] items-center gap-x-4";
+const GRID =
+  "grid grid-cols-[minmax(9rem,1fr)_4rem_4rem_5rem_5rem_minmax(6rem,1.5fr)] items-center gap-x-4";
 
 interface ToolUsage {
   name: string;
@@ -48,7 +49,10 @@ export function ToolCallsSection({ trace, onSelect }: ToolCallsSectionProps) {
   const totalCalls = usage.reduce((a, u) => a + u.calls.length, 0);
 
   return (
-    <Section title="tools" meta={`${totalCalls} calls across ${usage.length} tools · click a tool for its calls`}>
+    <Section
+      title="tools"
+      meta={`${totalCalls} calls across ${usage.length} tools · click a tool for its calls`}
+    >
       <div className="type-accent-s px-6 pb-4">
         <div className={cn(GRID, "border-b border-ta-grey-400 pb-1 text-ta-grey-200")}>
           <span>tool</span>
@@ -63,6 +67,7 @@ export function ToolCallsSection({ trace, onSelect }: ToolCallsSectionProps) {
         {usage.map((tool) => (
           <Fragment key={tool.name}>
             <button
+              type="button"
               onClick={() => setOpenTool((v) => (v === tool.name ? null : tool.name))}
               aria-expanded={openTool === tool.name}
               className={cn(
@@ -73,7 +78,12 @@ export function ToolCallsSection({ trace, onSelect }: ToolCallsSectionProps) {
             >
               <span className="truncate text-ta-sand-50">{tool.name}</span>
               <span className="text-right text-ta-grey-100">{tool.calls.length}</span>
-              <span className={cn("text-right", tool.failures > 0 ? "text-ta-error" : "text-ta-grey-300")}>
+              <span
+                className={cn(
+                  "text-right",
+                  tool.failures > 0 ? "text-ta-error" : "text-ta-grey-300",
+                )}
+              >
                 {tool.failures > 0 ? tool.failures : "-"}
               </span>
               <span className="text-right text-ta-grey-100">
@@ -90,6 +100,7 @@ export function ToolCallsSection({ trace, onSelect }: ToolCallsSectionProps) {
             {openTool === tool.name &&
               tool.calls.map((call) => (
                 <button
+                  type="button"
                   key={`${call.gen}:${call.id}`}
                   onClick={() => onSelect(call.gen)}
                   title="jump to this generation"

--- a/src/viewer/components/Treemap.tsx
+++ b/src/viewer/components/Treemap.tsx
@@ -1,7 +1,7 @@
-import { hierarchy, treemap, treemapSquarify, type HierarchyRectangularNode } from "d3-hierarchy";
-import { useMemo } from "react";
-import type { BreakdownGroupKey } from "@core/types";
 import { formatTokens } from "@core/format";
+import type { BreakdownGroupKey } from "@core/types";
+import { type HierarchyRectangularNode, hierarchy, treemap, treemapSquarify } from "d3-hierarchy";
+import { useMemo } from "react";
 import type { TreemapGroupData, TreemapLeaf } from "@/lib/treemap-data";
 import { useElementSize } from "@/lib/use-element-size";
 import { cn } from "@/lib/utils";
@@ -113,7 +113,9 @@ function GroupBlock({ node, group, children }: GroupBlockProps) {
         style={{ left: node.x0, top: node.y0, width, height: node.y1 - node.y0 }}
       >
         {width > 70 && (
-          <span className={cn("type-accent-s absolute left-1 top-0.5", GROUP_STYLE[group.key].label)}>
+          <span
+            className={cn("type-accent-s absolute left-1 top-0.5", GROUP_STYLE[group.key].label)}
+          >
             {group.key} ~{formatTokens(group.estTokens)}
           </span>
         )}
@@ -137,6 +139,7 @@ function LeafBlock({ node, leaf, onInspect, onOpen }: LeafBlockProps) {
   const style = GROUP_STYLE[leaf.group];
   return (
     <button
+      type="button"
       className={cn(
         "absolute cursor-pointer overflow-hidden text-left transition-colors",
         leaf.cached ? style.cachedBlock : style.block,

--- a/src/viewer/components/TreemapSection.tsx
+++ b/src/viewer/components/TreemapSection.tsx
@@ -1,16 +1,12 @@
-import { useMemo, useState } from "react";
-import type { Generation, NormalizedTrace } from "@core/types";
 import { formatPercent, formatTokens } from "@core/format";
+import type { Generation, NormalizedTrace } from "@core/types";
+import { useMemo, useState } from "react";
 import { DefinitionDialog } from "@/components/DefinitionDialog";
 import { Treemap } from "@/components/Treemap";
 import { Hint } from "@/components/ui/hint";
 import { Section } from "@/components/ui/section";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  buildTreemapData,
-  type TreemapScope,
-  type TreemapSizeBy,
-} from "@/lib/treemap-data";
+import { buildTreemapData, type TreemapScope, type TreemapSizeBy } from "@/lib/treemap-data";
 
 interface TreemapSectionProps {
   trace: NormalizedTrace;
@@ -86,14 +82,20 @@ export function TreemapSection({ trace, generation }: TreemapSectionProps) {
                 ~{formatTokens(inspected.estTokens)} tok (
                 {formatPercent(inspected.estTokens, totalTokens)})
                 {inspected.sentCount > 1 ? ` sent ${inspected.sentCount}x` : ""}
-                {inspected.cached === undefined ? "" : inspected.cached ? " · repeated prefix" : " · fresh"}
+                {inspected.cached === undefined
+                  ? ""
+                  : inspected.cached
+                    ? " · repeated prefix"
+                    : " · fresh"}
               </span>
               <span className="type-body-s min-w-0 truncate normal-case text-ta-grey-200">
                 {inspected.preview || "(no text)"}
               </span>
             </>
           ) : (
-            <span className="text-ta-grey-200">hover a block to inspect it · click to pin its full definition</span>
+            <span className="text-ta-grey-200">
+              hover a block to inspect it · click to pin its full definition
+            </span>
           )}
         </div>
         {pinned && (

--- a/src/viewer/components/Waterfall.tsx
+++ b/src/viewer/components/Waterfall.tsx
@@ -1,7 +1,7 @@
-import { Fragment } from "react";
+import { formatCallNames, formatCost, formatSeconds, formatTokens } from "@core/format";
 import { toolCallNames } from "@core/normalize";
 import type { NormalizedTrace } from "@core/types";
-import { formatCallNames, formatCost, formatSeconds, formatTokens } from "@core/format";
+import { Fragment } from "react";
 import { cn } from "@/lib/utils";
 
 interface WaterfallProps {
@@ -25,6 +25,7 @@ export function Waterfall({ trace, selectedIndex, onSelect }: WaterfallProps) {
               </p>
             )}
             <button
+              type="button"
               onClick={() => onSelect(gen.index)}
               aria-pressed={gen.index === selectedIndex}
               title={`${formatTokens(gen.metrics.inputTokens)} in / ${formatTokens(gen.metrics.outputTokens)} out${gen.metrics.cost > 0 ? ` · ${formatCost(gen.metrics.cost)}` : ""}`}

--- a/src/viewer/components/ui/button.tsx
+++ b/src/viewer/components/ui/button.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 function Button({ className, ...props }: ComponentProps<"button">) {
   return (
     <button
+      type="button"
       className={cn(
         "type-accent-s inline-flex h-7 cursor-pointer items-center border border-ta-grey-400 px-3 text-ta-grey-100",
         "transition-colors hover:border-ta-sand-300 hover:text-ta-sand-50",

--- a/src/viewer/components/ui/section.tsx
+++ b/src/viewer/components/ui/section.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { Hint } from "@/components/ui/hint";
 import type { GlossaryTerm } from "@/lib/glossary";
 import { cn } from "@/lib/utils";
@@ -31,6 +31,7 @@ export function Section({
     <section className={cn("border-b border-ta-grey-400", className)}>
       <div className="flex min-h-13 items-center gap-4 px-6 py-2">
         <button
+          type="button"
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
           className="type-accent-m flex cursor-pointer items-center gap-2 text-ta-sand-50"

--- a/src/viewer/components/ui/tabs.tsx
+++ b/src/viewer/components/ui/tabs.tsx
@@ -19,10 +19,7 @@ function Tabs<T extends string>({ value, onValueChange, children }: TabsProps<T>
 
 function TabsList({ className, ...props }: ComponentProps<typeof BaseTabs.List>) {
   return (
-    <BaseTabs.List
-      className={cn("inline-flex border border-ta-grey-400", className)}
-      {...props}
-    />
+    <BaseTabs.List className={cn("inline-flex border border-ta-grey-400", className)} {...props} />
   );
 }
 

--- a/src/viewer/lib/treemap-data.ts
+++ b/src/viewer/lib/treemap-data.ts
@@ -1,8 +1,4 @@
-import type {
-  BreakdownGroupKey,
-  Generation,
-  NormalizedTrace,
-} from "@core/types";
+import type { BreakdownGroupKey, Generation, NormalizedTrace } from "@core/types";
 
 export type TreemapScope = "generation" | "cumulative";
 export type TreemapSizeBy = "tokens" | "cost";

--- a/src/viewer/lib/use-replay.ts
+++ b/src/viewer/lib/use-replay.ts
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
 import type { Generation, NormalizedTrace } from "@core/types";
+import { useEffect, useMemo, useState } from "react";
 
 export const SPEEDS = [1, 4, 8];
 

--- a/src/viewer/lib/use-trace.ts
+++ b/src/viewer/lib/use-trace.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface TraceState {
   /** One entry per independent run, chronological; absent until loaded. */

--- a/src/viewer/lib/utils.ts
+++ b/src/viewer/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 /** Merges Tailwind classes, later ones winning. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,8 +24,7 @@ function devTraceApi(): Plugin {
         const url = new URL(req.url ?? "", "http://localhost");
         const items = loadItems();
         const id = url.searchParams.get("id");
-        const item =
-          id === null ? items.at(-1) : items.find((it) => it.trace.traceId === id);
+        const item = id === null ? items.at(-1) : items.find((it) => it.trace.traceId === id);
         return { url, item };
       };
       const send = (res: import("node:http").ServerResponse, status: number, body: unknown) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
# Overview

Brings the repo up to nice-OSS baseline: linting, tests, CI, and contributor hygiene.

- **Biome 2.5.10** - single tool for formatting (2-space, double quotes, 100 cols, matches existing style) and recommended lint rules. `noNonNullAssertion` off (deliberate house pattern in core), Tailwind CSS excluded from parsing. Fixed everything it surfaced: explicit `type="button"` on all buttons, an unused param, a `forEach` return.
- **Vitest 4.1.11** - 34 tests over the load-bearing logic: the ai-sdk devtools adapter (detect, snapshot/pairing invariants, all three usage shapes, split trees + lineage, in-flight/error steps, naming), normalize (segments, tool pairing with late args, reasoning split, cache attribution, zero-input estimates), collections (depth, cycle guard), and a real-HTTP server integration suite covering the id-addressed API, SSE hello, the Host/Origin security guards, the live notify/clear cycle, and the oversized-body drop.
- **CI** - lint + typecheck + test + build on push/PR, actions SHA-pinned.
- **Hygiene** - PR template, .editorconfig, `npm run check` aggregate (also gates `prepublishOnly`), README dev docs.

## Test plan

- [x] `npm run check` passes (lint + typecheck + tests)
- [x] `npm run build` clean; CLI smoke-tested against the local fixture and real devtools dbs after the formatter pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tester-army/unbox-ai/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->