### PR TITLE
feat(viewer): file tabs, browser trace opening, agent copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ opens several trace files (any mix of formats) as one run list.
 - **Timeline waterfall** - latency per generation with TTFT marks, tokens, cost.
 - **Generation detail** - only the messages new since the previous generation,
   tool calls paired with their results, raw JSON one click away.
+- **File tabs** - `unbox-ai view a.json b.json` opens one tab per file; the
+  sidebar run list scopes to the active tab. Tabs close (x), and the + button
+  or dropping a .json anywhere opens more traces without restarting the
+  server.
 
 Token attribution is estimated (character-proportional, scaled to the reported
 per-generation totals) and labeled as such.
@@ -116,6 +120,10 @@ unbox-ai tools trace.json            # every tool call: status, time, size, args
 unbox-ai messages trace.json --grep "error" --role assistant --limit 10
 unbox-ai get trace.json 'events[5].messages[10].tool_calls[0]'
 ```
+
+In the viewer, **copy for agent** (header, top right) copies the exact
+`summary` command for the run on screen - paste it into your agent to hand
+over what you're looking at.
 
 Every command caps its output; truncations print the exact `get` invocation
 that returns the rest. `--json` gives machine-readable output. When stdout is

--- a/src/cli/live.ts
+++ b/src/cli/live.ts
@@ -26,7 +26,9 @@ export function createLiveSource(defaultDbPath: string): TraceSource & { reload(
       return false; // the app has not written anything yet
     }
     try {
-      snapshot = buildCollection(parseCollection(JSON.parse(text)).items);
+      snapshot = buildCollection(
+        parseCollection(JSON.parse(text)).items.map((item) => ({ ...item, sourcePath: dbPath })),
+      );
     } catch {
       // the app rewrites the file on every step, so a read can catch it
       // mid-write; keep the last good state - the next ping re-reads

--- a/src/cli/load.ts
+++ b/src/cli/load.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { resolveAdapter } from "../core/adapters";
 import { parseCollection, type TraceCollectionItem } from "../core/collection";
 import { normalizeTrace } from "../core/normalize";
@@ -33,7 +34,12 @@ export function loadTrace(path: string): LoadedTrace {
  */
 export function loadCollectionFiles(paths: string[]): TraceCollectionItem[] {
   try {
-    return paths.flatMap((path) => parseCollection(readJson(path)).items);
+    return paths.flatMap((path) =>
+      parseCollection(readJson(path)).items.map((item) => ({
+        ...item,
+        sourcePath: resolve(path),
+      })),
+    );
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error));
   }

--- a/src/cli/server.test.ts
+++ b/src/cli/server.test.ts
@@ -57,6 +57,31 @@ describe("api routes", () => {
     expect(((await res.json()) as { value: string }).value).toBe("test-model");
   });
 
+  it("serves the agent command, quoted and run-scoped as needed", async () => {
+    const plain = await serve(
+      staticSource([{ raw, trace: normalizeTrace(raw), sourcePath: "/tmp/trace.json" }]),
+    );
+    expect(await (await fetch(`${plain.base}/api/command`)).json()).toEqual({
+      command: "npx unbox-ai summary /tmp/trace.json",
+    });
+
+    const raw2: RawTrace = { ...raw, trace_id: "t2" };
+    const multi = await serve(
+      staticSource([
+        { raw, trace: normalizeTrace(raw), sourcePath: "/tmp/my traces.json" },
+        { raw: raw2, trace: normalizeTrace(raw2), sourcePath: "/tmp/my traces.json" },
+      ]),
+    );
+    expect(await (await fetch(`${multi.base}/api/command?id=t1`)).json()).toEqual({
+      command: "npx unbox-ai summary '/tmp/my traces.json' --run t1",
+    });
+  });
+
+  it("has no agent command without a source path", async () => {
+    const { base } = await serve();
+    expect((await fetch(`${base}/api/command`)).status).toBe(404);
+  });
+
   it("announces the mode over the event stream", async () => {
     const { base } = await serve();
     const res = await fetch(`${base}/api/events`);
@@ -141,6 +166,12 @@ describe("live mode", () => {
     });
     expect(notify.status).toBe(200);
     expect(((await (await fetch(`${base}/api/traces`)).json()) as unknown[]).length).toBe(2);
+
+    const { command } = (await (await fetch(`${base}/api/command?id=run-0`)).json()) as {
+      command: string;
+    };
+    expect(command).toContain(".devtools/generations.json");
+    expect(command).toContain("--run run-0");
 
     const outside = await fetch(`${base}/api/notify`, {
       method: "POST",

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -59,6 +59,22 @@ function pickTrace(collection: Collection, url: URL): ServedTrace | undefined {
   return collection.items.at(-1);
 }
 
+/**
+ * The shell command an agent runs to explore this run: the bounded `summary`
+ * entry point, scoped with --run when the source file holds several runs.
+ */
+function agentCommand(items: ServedTrace[], item: ServedTrace): string | undefined {
+  if (item.sourcePath === undefined) return undefined;
+  const multiRun = items.filter((other) => other.sourcePath === item.sourcePath).length > 1;
+  const run = multiRun ? ` --run ${shellQuote(item.trace.traceId)}` : "";
+  return `npx unbox-ai summary ${shellQuote(item.sourcePath)}${run}`;
+}
+
+/** Single-quotes a value unless it is plain enough to paste bare. */
+function shellQuote(value: string): string {
+  return /^[\w@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 /** Directory of built viewer assets, shipped next to the bundled CLI. */
 function viewerDir(): string {
   return fileURLToPath(new URL("../viewer", import.meta.url));
@@ -118,6 +134,16 @@ export async function startServer(
       const value = item && resolvePath(item.raw, url.searchParams.get("path") ?? "");
       res.writeHead(value === undefined ? 404 : 200, { "content-type": "application/json" });
       res.end(JSON.stringify(value === undefined ? { error: "nothing at path" } : { value }));
+      return;
+    }
+    if (url.pathname === "/api/command") {
+      const collection = source.current();
+      const item = pickTrace(collection, url);
+      const command = item && agentCommand(collection.items, item);
+      res.writeHead(command === undefined ? 404 : 200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify(command === undefined ? { error: "no command available" } : { command }),
+      );
       return;
     }
     if (url.pathname === "/api/events") {

--- a/src/core/collection.test.ts
+++ b/src/core/collection.test.ts
@@ -64,6 +64,13 @@ describe("runSummaries", () => {
     ]);
   });
 
+  it("passes the source path through for tab grouping", () => {
+    const sourced = { ...item("a"), sourcePath: "/tmp/a.json" };
+    const summaries = runSummaries([sourced, item("b")]);
+    expect(summaries[0]!.source).toBe("/tmp/a.json");
+    expect(summaries[1]!.source).toBeUndefined();
+  });
+
   it("survives lineage cycles", () => {
     const a = item("a", "b");
     const b = item("b", "a");

--- a/src/core/collection.ts
+++ b/src/core/collection.ts
@@ -5,6 +5,8 @@ import type { NormalizedTrace, RawTrace } from "./types";
 export interface TraceCollectionItem {
   raw: RawTrace;
   trace: NormalizedTrace;
+  /** Absolute path of the file this run came from; attached by loaders. */
+  sourcePath?: string;
 }
 
 export interface TraceCollection {
@@ -24,6 +26,8 @@ export interface RunSummary {
   inProgress?: boolean;
   /** Nesting level under the spawning run; 0 for roots. */
   depth: number;
+  /** Absolute path of the file this run came from; groups runs into tabs. */
+  source?: string;
 }
 
 /**
@@ -44,7 +48,7 @@ export function parseCollection(json: unknown): TraceCollection {
 
 export function runSummaries(items: TraceCollectionItem[]): RunSummary[] {
   const parents = new Map(items.map(({ trace }) => [trace.traceId, trace.parentTraceId]));
-  return items.map(({ trace }) => ({
+  return items.map(({ trace, sourcePath }) => ({
     id: trace.traceId,
     name: trace.name,
     timestamp: trace.timestamp,
@@ -53,6 +57,7 @@ export function runSummaries(items: TraceCollectionItem[]): RunSummary[] {
     models: trace.models,
     ...(trace.inProgress ? { inProgress: true } : {}),
     depth: depthOf(trace.traceId, parents),
+    ...(sourcePath !== undefined ? { source: sourcePath } : {}),
   }));
 }
 

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -5,6 +5,7 @@ import { GenerationDetail } from "@/components/GenerationDetail";
 import { Header } from "@/components/Header";
 import { ReplayBar } from "@/components/ReplayBar";
 import { RunList } from "@/components/RunList";
+import { OpenButton, SourceTabs, sourceTabs } from "@/components/SourceTabs";
 import { ToolCallsSection } from "@/components/ToolCallsSection";
 import { TreemapSection } from "@/components/TreemapSection";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -13,7 +14,18 @@ import { useReplay } from "@/lib/use-replay";
 import { useTrace } from "@/lib/use-trace";
 
 export function App() {
-  const { runs, trace, error, live, selectedRun, selectRun } = useTrace();
+  const {
+    runs,
+    trace,
+    error,
+    live,
+    selectedRun,
+    selectRun,
+    command,
+    openFiles,
+    closeSource,
+    openError,
+  } = useTrace();
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   if (error) {
@@ -31,6 +43,13 @@ export function App() {
         </Shell>
       );
     }
+    if (!live && runs?.length === 0) {
+      return (
+        <Shell {...dropHandlers(openFiles)}>
+          <NoOpenTraces onOpen={openFiles} openError={openError} />
+        </Shell>
+      );
+    }
     return (
       <Shell>
         <p className="type-accent-m p-8 text-ta-grey-200">loading trace...</p>
@@ -45,10 +64,25 @@ export function App() {
       selectedRun={selectedRun}
       onSelectRun={selectRun}
       live={live}
+      agentCommand={command}
+      openFiles={openFiles}
+      closeSource={closeSource}
+      openError={openError}
       selectedIndex={selectedIndex}
       onSelect={setSelectedIndex}
     />
   );
+}
+
+/** Static mode accepts trace files dropped anywhere in the window. */
+function dropHandlers(openFiles: (files: Iterable<File>) => void) {
+  return {
+    onDragOver: (e: React.DragEvent) => e.preventDefault(),
+    onDrop: (e: React.DragEvent) => {
+      e.preventDefault();
+      if (e.dataTransfer.files.length > 0) openFiles(e.dataTransfer.files);
+    },
+  };
 }
 
 interface LoadedProps {
@@ -57,6 +91,10 @@ interface LoadedProps {
   selectedRun?: string;
   onSelectRun: (id: string) => void;
   live: boolean;
+  agentCommand?: string;
+  openFiles: (files: Iterable<File>) => void;
+  closeSource: (source: string) => void;
+  openError?: string;
   selectedIndex: number;
   onSelect: (index: number) => void;
 }
@@ -67,10 +105,19 @@ function Loaded({
   selectedRun,
   onSelectRun,
   live,
+  agentCommand,
+  openFiles,
+  closeSource,
+  openError,
   selectedIndex,
   onSelect,
 }: LoadedProps) {
   const replay = useReplay(trace);
+
+  // several opened files become tabs; devtools' live feed stays a plain list
+  const tabs = live ? [] : sourceTabs(runs);
+  const selectedSource = runs.find((run) => run.id === selectedRun)?.source;
+  const scopedRuns = tabs.length > 0 ? runs.filter((run) => run.source === selectedSource) : runs;
 
   // follow the playhead: the entered generation becomes the selection
   useEffect(() => {
@@ -113,16 +160,27 @@ function Loaded({
   };
 
   return (
-    <Shell>
+    <Shell {...(live ? {} : dropHandlers(openFiles))}>
       <Header
         trace={trace}
+        agentCommand={agentCommand}
         onClear={live ? () => void fetch("/api/clear", { method: "POST" }) : undefined}
       />
+      {tabs.length > 0 && (
+        <SourceTabs
+          tabs={tabs}
+          selectedSource={selectedSource}
+          onSelect={(tab) => onSelectRun(tab.runs.at(-1)!.id)}
+          onClose={closeSource}
+          onOpen={openFiles}
+          openError={openError}
+        />
+      )}
       <div className="flex min-h-0 flex-1">
         {/* stable gutters: a scrollbar appearing mid-stream must not shift the layout */}
         <aside className="w-80 shrink-0 overflow-y-auto border-r border-ta-grey-400 [scrollbar-gutter:stable]">
-          {runs.length > 1 && (
-            <RunList runs={runs} selectedId={selectedRun} onSelect={onSelectRun} />
+          {scopedRuns.length > 1 && (
+            <RunList runs={scopedRuns} selectedId={selectedRun} onSelect={onSelectRun} />
           )}
           <Waterfall trace={trace} selectedIndex={selected.index} onSelect={selectGeneration} />
         </aside>
@@ -210,9 +268,28 @@ function Snippet({ text }: { text: string }) {
   );
 }
 
-function Shell({ children }: { children: React.ReactNode }) {
+function NoOpenTraces({
+  onOpen,
+  openError,
+}: {
+  onOpen: (files: Iterable<File>) => void;
+  openError?: string;
+}) {
   return (
-    <div className="ta-landing flex h-screen flex-col bg-ta-grey-500 text-ta-sand-50">
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="flex w-full max-w-md flex-col items-center gap-4 border border-ta-grey-400 bg-ta-grey-450 px-8 py-10">
+        <p className="type-accent-m text-ta-sand-50">no open traces</p>
+        <OpenButton onOpen={onOpen}>open trace file</OpenButton>
+        <p className="type-body-s text-ta-grey-200">or drop a .json anywhere in this window</p>
+        {openError && <p className="type-accent-s text-ta-error">{openError}</p>}
+      </div>
+    </div>
+  );
+}
+
+function Shell({ children, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className="ta-landing flex h-screen flex-col bg-ta-grey-500 text-ta-sand-50" {...props}>
       {children}
     </div>
   );

--- a/src/viewer/components/DefinitionDialog.tsx
+++ b/src/viewer/components/DefinitionDialog.tsx
@@ -1,4 +1,5 @@
 import { contentToText } from "@core/normalize";
+import { resolvePath } from "@core/path";
 import { prettyArgs, prettyPayload } from "@core/pretty";
 import type { RawMessage, RawToolDef } from "@core/types";
 import { useEffect, useState } from "react";
@@ -7,6 +8,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Markdown } from "@/components/ui/markdown";
 import type { TreemapLeaf } from "@/lib/treemap-data";
+import { localRawTrace } from "@/lib/use-trace";
 
 /** Full definition of a clicked treemap block: pretty-rendered, raw JSON a toggle away. */
 export function DefinitionDialog({
@@ -160,6 +162,13 @@ function Mono({ children }: { children: string }) {
 
 /** Fetches a raw-trace value, failing legibly when the server is older than the viewer. */
 async function fetchRawValue(traceId: string, ref: string): Promise<unknown> {
+  // browser-opened files never reached the server; resolve against local raw
+  const local = localRawTrace(traceId);
+  if (local !== undefined) {
+    const value = resolvePath(local, ref);
+    if (value === undefined) throw new Error("nothing at path");
+    return value;
+  }
   const res = await fetch(
     `/api/raw?id=${encodeURIComponent(traceId)}&path=${encodeURIComponent(ref)}`,
   );

--- a/src/viewer/components/Header.tsx
+++ b/src/viewer/components/Header.tsx
@@ -1,21 +1,26 @@
 import { formatCost, formatSeconds, formatTokens } from "@core/format";
 import type { NormalizedTrace } from "@core/types";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Hint } from "@/components/ui/hint";
 
 interface HeaderProps {
   trace: NormalizedTrace;
+  /** Shell command an agent runs to explore this run from the CLI. */
+  agentCommand?: string;
   /** Present in live devtools mode; empties the backing database. */
   onClear?: () => void;
 }
 
-export function Header({ trace, onClear }: HeaderProps) {
+export function Header({ trace, agentCommand, onClear }: HeaderProps) {
   return (
-    <header className="flex items-baseline gap-6 border-b border-ta-grey-400 px-6 py-4">
-      <h1 className="type-accent-m text-ta-orange-300">unbox-ai</h1>
+    <header className="flex items-baseline gap-6 overflow-hidden border-b border-ta-grey-400 px-6 py-4">
+      <h1 className="type-accent-m shrink-0 text-ta-orange-300">unbox-ai</h1>
       <span className="type-body-m min-w-0 truncate text-ta-sand-50">{trace.name}</span>
-      <span className="type-accent-s text-ta-grey-200">{trace.models.join(", ")}</span>
-      <div className="type-accent-s ml-auto flex shrink-0 items-baseline gap-6 text-ta-grey-100">
+      <span className="type-accent-s min-w-0 truncate text-ta-grey-200">
+        {trace.models.join(", ")}
+      </span>
+      <div className="type-accent-s ml-auto flex shrink-0 items-baseline gap-6 whitespace-nowrap text-ta-grey-100">
         <Stat
           label={<Hint term="generation">generations</Hint>}
           value={String(trace.generations.length)}
@@ -29,6 +34,17 @@ export function Header({ trace, onClear }: HeaderProps) {
         />
         {/* traces without price data report 0 - a real run never costs exactly $0 */}
         {trace.totalCost > 0 && <Stat label="cost" value={formatCost(trace.totalCost)} />}
+        {agentCommand ? (
+          <CopyButton label="copy for agent" text={agentCommand} title={agentCommand} />
+        ) : (
+          <Button
+            disabled
+            className="cursor-default opacity-40 hover:border-ta-grey-400 hover:text-ta-grey-100"
+            title="opened in this browser - agents need a file on disk"
+          >
+            copy for agent
+          </Button>
+        )}
         {onClear && <Button onClick={onClear}>clear</Button>}
       </div>
     </header>

--- a/src/viewer/components/SourceTabs.tsx
+++ b/src/viewer/components/SourceTabs.tsx
@@ -1,0 +1,182 @@
+import type { RunSummary } from "@core/collection";
+import { useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface SourceTab {
+  /** Absolute path (server files) or file name (browser-opened); the grouping key. */
+  source: string;
+  label: string;
+  runs: RunSummary[];
+}
+
+/**
+ * Groups runs into one tab per source file, in first-seen order. Any run
+ * without a source hides the tabs - partial grouping would drop runs.
+ */
+export function sourceTabs(runs: RunSummary[]): SourceTab[] {
+  const bySource = new Map<string, RunSummary[]>();
+  for (const run of runs) {
+    if (run.source === undefined) return [];
+    const group = bySource.get(run.source);
+    if (group) group.push(run);
+    else bySource.set(run.source, [run]);
+  }
+  const sources = [...bySource.keys()];
+  const labels = disambiguate(sources);
+  return sources.map((source) => ({
+    source,
+    label: labels.get(source)!,
+    runs: bySource.get(source)!,
+  }));
+}
+
+/** Basenames, widened to parent/basename when two files share a name. */
+function disambiguate(sources: string[]): Map<string, string> {
+  const segments = (path: string) => path.split(/[\\/]/).filter(Boolean);
+  const base = (path: string) => segments(path).at(-1) ?? path;
+  const counts = new Map<string, number>();
+  for (const source of sources) counts.set(base(source), (counts.get(base(source)) ?? 0) + 1);
+  return new Map(
+    sources.map((source) => [
+      source,
+      counts.get(base(source))! > 1 ? segments(source).slice(-2).join("/") : base(source),
+    ]),
+  );
+}
+
+interface SourceTabsProps {
+  tabs: SourceTab[];
+  selectedSource?: string;
+  onSelect: (tab: SourceTab) => void;
+  onClose: (source: string) => void;
+  onOpen: (files: Iterable<File>) => void;
+  /** Last file that failed to open, shown at the end of the strip. */
+  openError?: string;
+}
+
+/** One tab per opened trace file; the sidebar run list scopes to the active one. */
+export function SourceTabs({
+  tabs,
+  selectedSource,
+  onSelect,
+  onClose,
+  onOpen,
+  openError,
+}: SourceTabsProps) {
+  return (
+    <div className="flex shrink-0 items-center overflow-x-auto border-b border-ta-grey-400">
+      {tabs.map((tab) => {
+        const selected = tab.source === selectedSource;
+        return (
+          <div
+            key={tab.source}
+            className={cn(
+              "group relative flex shrink-0 items-stretch border-r border-ta-grey-400 transition-colors",
+              selected
+                ? "bg-ta-grey-450 text-ta-sand-50"
+                : "text-ta-grey-200 hover:bg-ta-grey-450/40 hover:text-ta-grey-100",
+            )}
+          >
+            {selected && (
+              <span aria-hidden className="absolute inset-x-0 top-0 h-0.5 bg-ta-orange-300" />
+            )}
+            <button
+              type="button"
+              onClick={() => onSelect(tab)}
+              aria-pressed={selected}
+              title={tab.source}
+              className="type-accent-s flex cursor-pointer items-center gap-2 py-2.5 pl-4"
+            >
+              <span className="max-w-48 truncate">{tab.label}</span>
+              {tab.runs.length > 1 && (
+                <span className={selected ? "text-ta-grey-200" : "text-ta-grey-300"}>
+                  {tab.runs.length}
+                </span>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => onClose(tab.source)}
+              aria-label={`close ${tab.label}`}
+              className={cn(
+                "cursor-pointer px-2.5 text-ta-grey-300 transition-opacity hover:text-ta-sand-50",
+                selected ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+              )}
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+      <OpenButton
+        onOpen={onOpen}
+        title="open trace files (or drop .json anywhere)"
+        className="h-auto self-stretch border-0 border-r border-ta-grey-400 px-4 text-ta-grey-200 hover:border-ta-grey-400 hover:bg-ta-grey-450/40 hover:text-ta-sand-50"
+      >
+        + open
+      </OpenButton>
+      {openError && (
+        <span className="type-accent-s ml-auto truncate px-4 text-ta-error">{openError}</span>
+      )}
+    </div>
+  );
+}
+
+/** window.showOpenFilePicker, on browsers that have it (Chromium). */
+type FilePicker = (options: {
+  multiple: boolean;
+  types?: { description: string; accept: Record<string, string[]> }[];
+}) => Promise<{ getFile(): Promise<File> }[]>;
+
+/** A DS button that picks trace files; opens them without a server. */
+export function OpenButton({
+  onOpen,
+  title,
+  className,
+  children,
+}: {
+  onOpen: (files: Iterable<File>) => void;
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const open = async () => {
+    // a file input's `multiple` is ignored by some embedded browsers; the
+    // picker API states multi-selection explicitly, so prefer it
+    const picker = (window as { showOpenFilePicker?: FilePicker }).showOpenFilePicker;
+    if (picker === undefined) {
+      inputRef.current?.click();
+      return;
+    }
+    try {
+      const handles = await picker({
+        multiple: true,
+        types: [{ description: "AI traces", accept: { "application/json": [".json"] } }],
+      });
+      const files = await Promise.all(handles.map((handle) => handle.getFile()));
+      if (files.length > 0) onOpen(files);
+    } catch {
+      // picker dismissed
+    }
+  };
+  return (
+    <>
+      <Button title={title} className={className} onClick={() => void open()}>
+        {children}
+      </Button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".json,application/json"
+        multiple
+        hidden
+        onChange={(e) => {
+          if (e.target.files?.length) onOpen(e.target.files);
+          e.target.value = "";
+        }}
+      />
+    </>
+  );
+}

--- a/src/viewer/components/ui/copy-button.tsx
+++ b/src/viewer/components/ui/copy-button.tsx
@@ -4,11 +4,14 @@ import { Button } from "@/components/ui/button";
 interface CopyButtonProps {
   /** Text to copy, or a producer so large strings aren't built until needed. */
   text: string | (() => string);
+  /** Idle label; the confirmation always reads "copied". */
+  label?: string;
+  title?: string;
   className?: string;
 }
 
 /** Copies text to the clipboard with a brief "copied" confirmation. */
-export function CopyButton({ text, className }: CopyButtonProps) {
+export function CopyButton({ text, label = "copy", title, className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
@@ -16,6 +19,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
   return (
     <Button
       className={className}
+      title={title}
       onClick={async (e) => {
         e.stopPropagation();
         const value = typeof text === "function" ? text() : text;
@@ -37,7 +41,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
         timer.current = setTimeout(() => setCopied(false), 1200);
       }}
     >
-      {copied ? "copied" : "copy"}
+      {copied ? "copied" : label}
     </Button>
   );
 }

--- a/src/viewer/lib/use-trace.ts
+++ b/src/viewer/lib/use-trace.ts
@@ -1,5 +1,10 @@
-import type { RunSummary } from "@core/collection";
-import type { NormalizedTrace } from "@core/types";
+import {
+  parseCollection,
+  type RunSummary,
+  runSummaries,
+  type TraceCollectionItem,
+} from "@core/collection";
+import type { NormalizedTrace, RawTrace } from "@core/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface TraceState {
@@ -7,9 +12,21 @@ interface TraceState {
   runs?: RunSummary[];
   trace?: NormalizedTrace;
   selectedRun?: string;
+  /** Copyable shell command for an agent to explore the selected run. */
+  command?: string;
   error?: string;
+  /** Last failure opening a picked/dropped file; cleared on the next attempt. */
+  openError?: string;
   /** True when the server pushes updates (unbox-ai devtools mode). */
   live: boolean;
+}
+
+/** Raw traces of browser-opened files; stands in for /api/raw on their runs. */
+const localRaws = new Map<string, RawTrace>();
+
+/** The raw trace behind a browser-opened run, or undefined for server runs. */
+export function localRawTrace(traceId: string): RawTrace | undefined {
+  return localRaws.get(traceId);
 }
 
 /**
@@ -17,19 +34,33 @@ interface TraceState {
  * (/api/trace?id=...), refetching both on every /api/events update push.
  * Follows the newest run until the user picks an older one; the browser
  * reconnects the event stream by itself after server restarts.
+ *
+ * Files opened in the browser (openFiles) are parsed locally and merged into
+ * the run list; closed sources (closeSource) are hidden. Both last until the
+ * page reloads.
  */
-export function useTrace(): TraceState & { selectRun: (id: string) => void } {
+export function useTrace(): TraceState & {
+  selectRun: (id: string) => void;
+  openFiles: (files: Iterable<File>) => void;
+  closeSource: (source: string) => void;
+} {
   const [state, setState] = useState<TraceState>({ live: false });
   const selectedRef = useRef<string | undefined>(undefined);
   const pinnedRef = useRef(false);
   const seqRef = useRef(0);
   const loadRef = useRef(() => {});
+  const localItemsRef = useRef<TraceCollectionItem[]>([]);
+  const closedRef = useRef(new Set<string>());
+  const runsRef = useRef<RunSummary[]>([]);
 
   const load = useCallback(async () => {
     const seq = ++seqRef.current;
     try {
-      const runs = (await fetchJson("/api/traces")) as RunSummary[];
-      const latest = runs.at(-1)?.id;
+      const serverRuns = (await fetchJson("/api/traces")) as RunSummary[];
+      const runs = [...serverRuns, ...runSummaries(localItemsRef.current)].filter(
+        (run) => run.source === undefined || !closedRef.current.has(run.source),
+      );
+      const latest = defaultRun(runs);
       let selected = selectedRef.current;
       if (
         selected === undefined ||
@@ -40,13 +71,29 @@ export function useTrace(): TraceState & { selectRun: (id: string) => void } {
         pinnedRef.current = false;
       }
       selectedRef.current = selected;
-      const trace =
+      const local = localItemsRef.current.find((item) => item.trace.traceId === selected);
+      const [trace, command] =
         selected === undefined
-          ? undefined
-          : ((await fetchJson(`/api/trace?id=${encodeURIComponent(selected)}`)) as NormalizedTrace);
+          ? [undefined, undefined]
+          : local
+            ? [local.trace, undefined]
+            : await Promise.all([
+                fetchJson(
+                  `/api/trace?id=${encodeURIComponent(selected)}`,
+                ) as Promise<NormalizedTrace>,
+                fetchCommand(selected),
+              ]);
       // update bursts overlap; only the newest request may win
       if (seq !== seqRef.current) return;
-      setState((prev) => ({ ...prev, runs, trace, selectedRun: selected, error: undefined }));
+      runsRef.current = runs;
+      setState((prev) => ({
+        ...prev,
+        runs,
+        trace,
+        command,
+        selectedRun: selected,
+        error: undefined,
+      }));
     } catch (error) {
       if (seq !== seqRef.current) return;
       // a transient refetch failure must not blank an already-loaded trace
@@ -72,14 +119,135 @@ export function useTrace(): TraceState & { selectRun: (id: string) => void } {
   const selectRun = useCallback(
     (id: string) => {
       selectedRef.current = id;
-      // picking an older run pins it; picking the newest resumes following
-      pinnedRef.current = id !== state.runs?.at(-1)?.id;
+      // picking anything but the follow target pins it; load() re-derives the
+      // target, so the comparison must use the same defaultRun
+      pinnedRef.current = id !== defaultRun(runsRef.current);
       load();
     },
-    [load, state.runs],
+    [load],
   );
 
-  return { ...state, selectRun };
+  const openFiles = useCallback((files: Iterable<File>) => {
+    void (async () => {
+      let lastOpened: TraceCollectionItem | undefined;
+      let failure: string | undefined;
+      for (const file of files) {
+        try {
+          const items = parseCollection(JSON.parse(await file.text())).items;
+          if (items.length === 0) throw new Error("no runs");
+          const adopted = adoptItems(items, uniqueSource(file.name, takenSources()), takenIds());
+          localItemsRef.current = [...localItemsRef.current, ...adopted];
+          lastOpened = adopted.at(-1);
+        } catch {
+          failure = `${file.name}: not a readable trace`;
+        }
+      }
+      if (lastOpened !== undefined) {
+        selectedRef.current = lastOpened.trace.traceId;
+        pinnedRef.current = true;
+      }
+      setState((prev) => ({ ...prev, openError: failure }));
+      loadRef.current();
+    })();
+
+    function takenSources(): Set<string> {
+      const taken = new Set(closedRef.current);
+      for (const run of runsRef.current) if (run.source !== undefined) taken.add(run.source);
+      for (const item of localItemsRef.current) taken.add(item.sourcePath!);
+      return taken;
+    }
+    function takenIds(): Set<string> {
+      const taken = new Set(runsRef.current.map((run) => run.id));
+      for (const item of localItemsRef.current) taken.add(item.trace.traceId);
+      return taken;
+    }
+  }, []);
+
+  const closeSource = useCallback((source: string) => {
+    const runs = runsRef.current;
+    const order = [...new Set(runs.map((run) => run.source))].filter(
+      (s): s is string => s !== undefined,
+    );
+    closedRef.current.add(source);
+    for (const item of localItemsRef.current) {
+      if (item.sourcePath === source) localRaws.delete(item.trace.traceId);
+    }
+    localItemsRef.current = localItemsRef.current.filter((item) => item.sourcePath !== source);
+    // closing the active tab activates its right neighbor, else the left one
+    if (runs.find((run) => run.id === selectedRef.current)?.source === source) {
+      const index = order.indexOf(source);
+      const next = order[index + 1] ?? order[index - 1];
+      const target =
+        next !== undefined ? runs.filter((run) => run.source === next).at(-1) : undefined;
+      selectedRef.current = target?.id;
+      pinnedRef.current = target !== undefined;
+    }
+    loadRef.current();
+  }, []);
+
+  return { ...state, selectRun, openFiles, closeSource };
+}
+
+/**
+ * Several opened files start on the first file's newest run - tabs read left
+ * to right. A single source (live devtools included) follows its newest run.
+ */
+function defaultRun(runs: RunSummary[]): string | undefined {
+  const first = runs[0];
+  if (first?.source === undefined) return runs.at(-1)?.id;
+  const sameSource = runs.filter((run) => run.source === first.source);
+  return sameSource.length === runs.length ? runs.at(-1)?.id : sameSource.at(-1)?.id;
+}
+
+/** The dropped file's name, counted up when a tab by that name already exists. */
+function uniqueSource(name: string, taken: Set<string>): string {
+  if (!taken.has(name)) return name;
+  for (let n = 2; ; n++) if (!taken.has(`${name} (${n})`)) return `${name} (${n})`;
+}
+
+/**
+ * Tags parsed runs with their tab source and de-collides run ids against
+ * already-listed ones (reopening a served file), keeping parent links whole.
+ */
+function adoptItems(
+  items: TraceCollectionItem[],
+  source: string,
+  takenIds: Set<string>,
+): TraceCollectionItem[] {
+  const rename = new Map<string, string>();
+  for (const { trace } of items) {
+    let id = trace.traceId;
+    if (takenIds.has(id)) {
+      let n = 2;
+      while (takenIds.has(`${id} (${n})`)) n++;
+      id = `${id} (${n})`;
+      rename.set(trace.traceId, id);
+    }
+    takenIds.add(id);
+  }
+  return items.map((item) => {
+    const trace = {
+      ...item.trace,
+      traceId: rename.get(item.trace.traceId) ?? item.trace.traceId,
+      parentTraceId:
+        item.trace.parentTraceId !== undefined
+          ? (rename.get(item.trace.parentTraceId) ?? item.trace.parentTraceId)
+          : undefined,
+    };
+    localRaws.set(trace.traceId, item.raw);
+    return { raw: item.raw, trace, sourcePath: source };
+  });
+}
+
+/** Sources without a file path (or older servers) have no command; not an error. */
+async function fetchCommand(id: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(`/api/command?id=${encodeURIComponent(id)}`);
+    if (!res.ok) return undefined;
+    return ((await res.json()) as { command: string }).command;
+  } catch {
+    return undefined;
+  }
 }
 
 async function fetchJson(url: string): Promise<unknown> {


### PR DESCRIPTION
# Overview

Three viewer upgrades that build on each other:

- **copy for agent** (header): copies `npx unbox-ai summary <file> [--run <id>]` for the run on screen - paste into an agent to hand over exactly what you are looking at. New `/api/command` endpoint builds it server-side from a per-run `sourcePath` now threaded through loaders.
- **file tabs**: `unbox-ai view a.json b.json` opens one vscode-style tab per file (top accent, close x, run-count badge); the sidebar run list scopes to the active tab and run numbers now match per-file `--run` indexes. Devtools live mode intentionally keeps its flat run list.
- **open traces in-browser**: + button (showOpenFilePicker, multi-select) or drop .json anywhere; files parse client-side via core's `parseCollection`, the raw-definition dialog resolves locally, run ids de-collide on reopen. Copy-for-agent renders disabled for these (no file on disk for an agent).

Also locks the header to a single line so switching tabs never shifts the layout (model list used to wrap).

## Test plan

Drove the viewer via browser automation: tab switching (incl. last tab - fixed a follow-target snap-back), closing inactive/active/all tabs, drop of valid/broken/duplicate files, raw dialog on a local trace, devtools live regression (no tabs, clear button intact), header geometry identical across all tabs.

- [x] `npm run check` passes (lint + typecheck + tests)
- [x] Verified against a real trace/db where the change is user-visible
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tester-army/unbox-ai/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->