### PR TITLE
feat: A/B trace compare in CLI and viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ unbox-ai compare a.json b.json       # A/B two runs: metric deltas + system prom
 `compare` is built for prompt and model A/B: it prints token / cost / time /
 cache deltas, then a line diff of the system prompt and the added / removed /
 changed tool definitions - "what changed and what did it buy". Add
-`--trajectory` for an aligned per-generation action table that marks where
-the runs diverged. Two runs of one file: `unbox-ai compare db.json --run 0
+`--trajectory` for a content-aligned action table (LCS over tool sequences,
+so an extra step in one run offsets nothing) that marks exactly which steps
+differ. Two runs of one file: `unbox-ai compare db.json --run 0
 --run 1`. The viewer has the same thing interactively: a **compare** button
 (2+ runs) opens a side-by-side trajectory where each aligned generation
 expands into both runs' messages.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,13 @@ unbox-ai event trace.json 5          # one generation, new messages only
 unbox-ai tools trace.json            # every tool call: status, time, size, args
 unbox-ai messages trace.json --grep "error" --role assistant --limit 10
 unbox-ai get trace.json 'events[5].messages[10].tool_calls[0]'
+unbox-ai compare a.json b.json       # A/B two runs: metric deltas + system prompt / tool diff
 ```
+
+`compare` is built for prompt and model A/B: it prints token / cost / time /
+cache deltas, then a line diff of the system prompt and the added / removed /
+changed tool definitions - "what changed and what did it buy". Two runs of one
+file: `unbox-ai compare db.json --run 0 --run 1`.
 
 In the viewer, **copy for agent** (header, top right) copies the exact
 `summary` command for the run on screen - paste it into your agent to hand

--- a/README.md
+++ b/README.md
@@ -124,8 +124,12 @@ unbox-ai compare a.json b.json       # A/B two runs: metric deltas + system prom
 
 `compare` is built for prompt and model A/B: it prints token / cost / time /
 cache deltas, then a line diff of the system prompt and the added / removed /
-changed tool definitions - "what changed and what did it buy". Two runs of one
-file: `unbox-ai compare db.json --run 0 --run 1`.
+changed tool definitions - "what changed and what did it buy". Add
+`--trajectory` for an aligned per-generation action table that marks where
+the runs diverged. Two runs of one file: `unbox-ai compare db.json --run 0
+--run 1`. The viewer has the same thing interactively: a **compare** button
+(2+ runs) opens a side-by-side trajectory where each aligned generation
+expands into both runs' messages.
 
 In the viewer, **copy for agent** (header, top right) copies the exact
 `summary` command for the run on screen - paste it into your agent to hand

--- a/skills/unbox-ai/SKILL.md
+++ b/skills/unbox-ai/SKILL.md
@@ -23,6 +23,7 @@ unbox-ai events <trace>         # table: tokens, latency, cost per generation
 unbox-ai event <trace> <idx>    # one generation: metrics + only its NEW messages
 unbox-ai messages <trace> --grep <q> [--role r] [--event n] [--limit n]
 unbox-ai get <trace> '<path>'   # exact raw value, e.g. events[3].messages[2].content
+unbox-ai compare <a> <b>        # A/B: metric deltas + system prompt / tool-set diff
 ```
 
 - `--json` on summary/events/event/tools/messages for machine-readable output
@@ -35,6 +36,10 @@ unbox-ai get <trace> '<path>'   # exact raw value, e.g. events[3].messages[2].co
   rest. Follow those pointers instead of guessing paths.
 - `--grep` accepts regex; invalid regex silently falls back to literal search.
 - `tools --all` lists every individual call with args.
+- `compare` answers "what changed between these two runs": token/cost/time
+  deltas, then a line diff of the system prompt and added/removed/changed
+  tools. Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
+  scopes A, second B). Diff output is bounded; `--json` has the full diff.
 - `unbox-ai view <trace>` starts a localhost visualization - only offer this
   to the human; as an agent, stay on the read commands.
 

--- a/skills/unbox-ai/SKILL.md
+++ b/skills/unbox-ai/SKILL.md
@@ -40,9 +40,10 @@ unbox-ai compare <a> <b>        # A/B: metric deltas + system prompt / tool-set 
   deltas, then a line diff of the system prompt and added/removed/changed
   tools. Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
   scopes A, second B). Diff output is bounded; `--json` has the full diff.
-  `--trajectory` adds an aligned per-generation action table (* = the runs
-  called different tools at that step) - the fastest way to find where two
-  runs diverged.
+  `--trajectory` adds a content-aligned action table (* = differing step,
+  - = no counterpart; alignment is LCS over tool sequences, so an extra step
+  in one run offsets nothing) - the fastest way to see where two runs
+  actually diverged.
 - `unbox-ai view <trace>` starts a localhost visualization - only offer this
   to the human; as an agent, stay on the read commands.
 

--- a/skills/unbox-ai/SKILL.md
+++ b/skills/unbox-ai/SKILL.md
@@ -40,6 +40,9 @@ unbox-ai compare <a> <b>        # A/B: metric deltas + system prompt / tool-set 
   deltas, then a line diff of the system prompt and added/removed/changed
   tools. Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
   scopes A, second B). Diff output is bounded; `--json` has the full diff.
+  `--trajectory` adds an aligned per-generation action table (* = the runs
+  called different tools at that step) - the fastest way to find where two
+  runs diverged.
 - `unbox-ai view <trace>` starts a localhost visualization - only offer this
   to the human; as an agent, stay on the read commands.
 

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -3,9 +3,14 @@ import {
   metricDelta,
   metricValue,
   type PromptDiff,
+  pairTrajectory,
   type ToolsDiff,
+  type TrajectoryStep,
 } from "../../core/compare";
 import type { DiffLine } from "../../core/diff";
+import { formatCallNames, formatSeconds, formatTokens } from "../../core/format";
+import { toolCallNames } from "../../core/normalize";
+import type { Generation } from "../../core/types";
 import type { LoadedTrace } from "../load";
 import { printJson, table } from "../output";
 
@@ -19,11 +24,22 @@ export function compare(
   a: LoadedTrace,
   b: LoadedTrace,
   labels: { a: string; b: string },
-  json: boolean,
+  options: { json: boolean; trajectory: boolean },
 ): void {
   const comparison = compareTraces(a, b);
-  if (json) {
-    printJson({ a: side(a, labels.a), b: side(b, labels.b), ...comparison });
+  const steps = pairTrajectory(a.trace, b.trace);
+  if (options.json) {
+    printJson({
+      a: side(a, labels.a),
+      b: side(b, labels.b),
+      ...comparison,
+      trajectory: steps.map((step) => ({
+        index: step.index,
+        diverged: step.diverged,
+        a: stepJson(step.a),
+        b: stepJson(step.b),
+      })),
+    });
     return;
   }
   console.log(`A  ${a.trace.name}  (${labels.a})`);
@@ -49,6 +65,46 @@ export function compare(
   console.log("");
   printPromptDiff(comparison.systemPrompt);
   printToolsDiff(comparison.tools);
+  if (options.trajectory) {
+    console.log("");
+    printTrajectory(steps);
+  } else if (steps.some((step) => step.diverged || step.a === undefined || step.b === undefined)) {
+    const at = steps.find((s) => s.diverged || s.a === undefined || s.b === undefined)!.index;
+    console.log(`\ntrajectories differ from generation ${at} - see: --trajectory`);
+  }
+}
+
+function stepJson(gen: Generation | undefined) {
+  if (gen === undefined) return null;
+  return {
+    tools: toolCallNames(gen),
+    inputTokens: gen.metrics.inputTokens,
+    outputTokens: gen.metrics.outputTokens,
+    latency: gen.metrics.latency,
+  };
+}
+
+/** Aligned per-generation actions; "*" marks steps where the runs did different things. */
+function printTrajectory(steps: TrajectoryStep[]): void {
+  console.log("trajectory (aligned by generation · * = different action)");
+  console.log(
+    table(
+      ["gen", "", "A", "B"],
+      steps.map((step) => [
+        String(step.index),
+        step.diverged ? "*" : "",
+        actionCell(step.a),
+        actionCell(step.b),
+      ]),
+    ),
+  );
+}
+
+function actionCell(gen: Generation | undefined): string {
+  if (gen === undefined) return "-";
+  const calls = formatCallNames(toolCallNames(gen));
+  const doing = calls !== "" ? calls : `-> ${(gen.newMessages.at(-1)?.text ?? "").slice(0, 32)}`;
+  return `${doing}  ${formatTokens(gen.metrics.inputTokens)} in ${formatSeconds(gen.metrics.latency)}`;
 }
 
 function side(loaded: LoadedTrace, label: string) {

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -34,7 +34,6 @@ export function compare(
       b: side(b, labels.b),
       ...comparison,
       trajectory: steps.map((step) => ({
-        index: step.index,
         diverged: step.diverged,
         a: stepJson(step.a),
         b: stepJson(step.b),
@@ -68,15 +67,24 @@ export function compare(
   if (options.trajectory) {
     console.log("");
     printTrajectory(steps);
-  } else if (steps.some((step) => step.diverged || step.a === undefined || step.b === undefined)) {
-    const at = steps.find((s) => s.diverged || s.a === undefined || s.b === undefined)!.index;
-    console.log(`\ntrajectories differ from generation ${at} - see: --trajectory`);
+  } else {
+    const different = steps.filter(
+      (step) => step.diverged || step.a === undefined || step.b === undefined,
+    );
+    if (different.length > 0) {
+      const at = different[0]!;
+      console.log(
+        `\ntrajectories differ at ${different.length} of ${steps.length} steps ` +
+          `(first at generation ${(at.a ?? at.b)!.index}) - see: --trajectory`,
+      );
+    }
   }
 }
 
 function stepJson(gen: Generation | undefined) {
   if (gen === undefined) return null;
   return {
+    index: gen.index,
     tools: toolCallNames(gen),
     inputTokens: gen.metrics.inputTokens,
     outputTokens: gen.metrics.outputTokens,
@@ -84,20 +92,30 @@ function stepJson(gen: Generation | undefined) {
   };
 }
 
-/** Aligned per-generation actions; "*" marks steps where the runs did different things. */
+/** Content-aligned per-generation actions; "*" marks steps where the runs differ. */
 function printTrajectory(steps: TrajectoryStep[]): void {
-  console.log("trajectory (aligned by generation · * = different action)");
+  console.log("trajectory (aligned by action · * = differs · - = no counterpart)");
   console.log(
     table(
       ["gen", "", "A", "B"],
       steps.map((step) => [
-        String(step.index),
-        step.diverged ? "*" : "",
+        indexCell(step),
+        step.diverged || step.a === undefined || step.b === undefined ? "*" : "",
         actionCell(step.a),
         actionCell(step.b),
       ]),
     ),
   );
+}
+
+/** "12" when both sides sit at the same generation, else "a12/b13" style. */
+function indexCell(step: TrajectoryStep): string {
+  if (step.a !== undefined && step.b !== undefined) {
+    return step.a.index === step.b.index
+      ? String(step.a.index)
+      : `a${step.a.index}/b${step.b.index}`;
+  }
+  return step.a !== undefined ? `a${step.a.index}` : `b${step.b!.index}`;
 }
 
 function actionCell(gen: Generation | undefined): string {

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -1,14 +1,18 @@
 import {
+  collectToolDefs,
   compareTraces,
   metricDelta,
   metricValue,
   type PromptDiff,
   pairTrajectory,
+  stepAction,
+  stepDiffers,
+  stepIndexLabel,
   type ToolsDiff,
   type TrajectoryStep,
 } from "../../core/compare";
 import type { DiffLine } from "../../core/diff";
-import { formatCallNames, formatSeconds, formatTokens } from "../../core/format";
+import { formatSeconds, formatTokens } from "../../core/format";
 import { toolCallNames } from "../../core/normalize";
 import type { Generation } from "../../core/types";
 import type { LoadedTrace } from "../load";
@@ -26,7 +30,11 @@ export function compare(
   labels: { a: string; b: string },
   options: { json: boolean; trajectory: boolean },
 ): void {
-  const comparison = compareTraces(a, b);
+  const comparable = (loaded: LoadedTrace) => ({
+    trace: loaded.trace,
+    tools: collectToolDefs(loaded.raw),
+  });
+  const comparison = compareTraces(comparable(a), comparable(b));
   const steps = pairTrajectory(a.trace, b.trace);
   if (options.json) {
     printJson({
@@ -68,9 +76,7 @@ export function compare(
     console.log("");
     printTrajectory(steps);
   } else {
-    const different = steps.filter(
-      (step) => step.diverged || step.a === undefined || step.b === undefined,
-    );
+    const different = steps.filter(stepDiffers);
     if (different.length > 0) {
       const at = different[0]!;
       console.log(
@@ -99,8 +105,8 @@ function printTrajectory(steps: TrajectoryStep[]): void {
     table(
       ["gen", "", "A", "B"],
       steps.map((step) => [
-        indexCell(step),
-        step.diverged || step.a === undefined || step.b === undefined ? "*" : "",
+        stepIndexLabel(step),
+        stepDiffers(step) ? "*" : "",
         actionCell(step.a),
         actionCell(step.b),
       ]),
@@ -108,21 +114,9 @@ function printTrajectory(steps: TrajectoryStep[]): void {
   );
 }
 
-/** "12" when both sides sit at the same generation, else "a12/b13" style. */
-function indexCell(step: TrajectoryStep): string {
-  if (step.a !== undefined && step.b !== undefined) {
-    return step.a.index === step.b.index
-      ? String(step.a.index)
-      : `a${step.a.index}/b${step.b.index}`;
-  }
-  return step.a !== undefined ? `a${step.a.index}` : `b${step.b!.index}`;
-}
-
 function actionCell(gen: Generation | undefined): string {
   if (gen === undefined) return "-";
-  const calls = formatCallNames(toolCallNames(gen));
-  const doing = calls !== "" ? calls : `-> ${(gen.newMessages.at(-1)?.text ?? "").slice(0, 32)}`;
-  return `${doing}  ${formatTokens(gen.metrics.inputTokens)} in ${formatSeconds(gen.metrics.latency)}`;
+  return `${stepAction(gen, 32)}  ${formatTokens(gen.metrics.inputTokens)} in ${formatSeconds(gen.metrics.latency)}`;
 }
 
 function side(loaded: LoadedTrace, label: string) {
@@ -135,15 +129,15 @@ function side(loaded: LoadedTrace, label: string) {
 }
 
 function printPromptDiff(diff: PromptDiff): void {
-  if (diff.same) {
+  if (diff.kind === "identical") {
     console.log(
-      diff.aChars === 0
+      diff.chars === 0
         ? "system prompt  none in either trace"
-        : `system prompt  identical (${diff.aChars} chars)`,
+        : `system prompt  identical (${diff.chars} chars)`,
     );
     return;
   }
-  if (diff.lines === undefined) {
+  if (diff.kind === "too-large") {
     console.log(
       `system prompt  differs (A ${diff.aChars} chars, B ${diff.bChars} chars - too large to line-diff, see --json)`,
     );

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -1,0 +1,150 @@
+import {
+  type ComparedMetric,
+  compareTraces,
+  type PromptDiff,
+  type ToolsDiff,
+} from "../../core/compare";
+import type { DiffLine } from "../../core/diff";
+import { formatCost, formatSeconds, formatTokens } from "../../core/format";
+import type { LoadedTrace } from "../load";
+import { printJson, table } from "../output";
+
+/** Bounded plain output; --json carries the full diff. */
+const MAX_DIFF_LINES = 40;
+const MAX_LINE_CHARS = 160;
+const MAX_NAMES = 8;
+
+/** Prints metric deltas and config differences between two loaded traces. */
+export function compare(
+  a: LoadedTrace,
+  b: LoadedTrace,
+  labels: { a: string; b: string },
+  json: boolean,
+): void {
+  const comparison = compareTraces(a, b);
+  if (json) {
+    printJson({ a: side(a, labels.a), b: side(b, labels.b), ...comparison });
+    return;
+  }
+  console.log(`A  ${a.trace.name}  (${labels.a})`);
+  console.log(`B  ${b.trace.name}  (${labels.b})`);
+  const { models } = comparison;
+  console.log(
+    models.a.join(", ") === models.b.join(", ")
+      ? `models  ${models.a.join(", ")}`
+      : `models  A: ${models.a.join(", ")}  B: ${models.b.join(", ")}`,
+  );
+  console.log("");
+  console.log(
+    table(
+      ["metric", "A", "B", "delta"],
+      comparison.metrics.map((m) => [m.key, value(m, m.a), value(m, m.b), delta(m)]),
+    ),
+  );
+  console.log("");
+  printPromptDiff(comparison.systemPrompt);
+  printToolsDiff(comparison.tools);
+}
+
+function side(loaded: LoadedTrace, label: string) {
+  return {
+    traceId: loaded.trace.traceId,
+    name: loaded.trace.name,
+    source: label,
+    format: loaded.format,
+  };
+}
+
+function value(metric: ComparedMetric, v: number): string {
+  switch (metric.kind) {
+    case "count":
+      return String(v);
+    case "tokens":
+      return formatTokens(v);
+    case "seconds":
+      return formatSeconds(v);
+    case "cost":
+      return formatCost(v);
+    case "share":
+      return `${Math.round(v * 100)}%`;
+  }
+}
+
+/** "-3 (-25%)" style delta, "pp" for share metrics, "=" when equal. */
+function delta(metric: ComparedMetric): string {
+  const d = metric.b - metric.a;
+  if (d === 0) return "=";
+  const sign = d > 0 ? "+" : "-";
+  const abs = Math.abs(d);
+  if (metric.kind === "share") {
+    const points = Math.round(abs * 100);
+    return points === 0 ? "=" : `${sign}${points}pp`;
+  }
+  const text = {
+    count: String(abs),
+    tokens: formatTokens(abs),
+    seconds: formatSeconds(abs),
+    cost: `$${abs.toFixed(4)}`,
+  }[metric.kind];
+  const relative = metric.a > 0 ? ` (${sign}${Math.round((abs / metric.a) * 100)}%)` : "";
+  return `${sign}${text}${relative}`;
+}
+
+function printPromptDiff(diff: PromptDiff): void {
+  if (diff.same) {
+    console.log(`system prompt  identical (${diff.aChars} chars)`);
+    return;
+  }
+  if (diff.lines === undefined) {
+    console.log(
+      `system prompt  differs (A ${diff.aChars} chars, B ${diff.bChars} chars - too large to line-diff, see --json)`,
+    );
+    return;
+  }
+  console.log(`system prompt  differs: +${diff.addedLines} / -${diff.removedLines} lines`);
+  const printable = hunks(diff.lines);
+  for (const line of printable.slice(0, MAX_DIFF_LINES)) console.log(`  ${line}`);
+  if (printable.length > MAX_DIFF_LINES) {
+    console.log(`  [... ${printable.length - MAX_DIFF_LINES} more diff lines - full diff: --json]`);
+  }
+}
+
+/** Changed lines with one context line around each run; "~" marks skipped stretches. */
+function hunks(lines: DiffLine[]): string[] {
+  const out: string[] = [];
+  const changed = (line?: DiffLine) => line !== undefined && line.kind !== "same";
+  const clip = (text: string) =>
+    text.length > MAX_LINE_CHARS ? `${text.slice(0, MAX_LINE_CHARS)}...` : text;
+  lines.forEach((line, i) => {
+    if (changed(line)) {
+      out.push(`${line.kind === "added" ? "+" : "-"} ${clip(line.text)}`);
+    } else if (changed(lines[i - 1]) || changed(lines[i + 1])) {
+      out.push(`  ${clip(line.text)}`);
+    } else if (out.at(-1) !== "~") {
+      out.push("~");
+    }
+  });
+  while (out[0] === "~") out.shift();
+  while (out.at(-1) === "~") out.pop();
+  return out;
+}
+
+function printToolsDiff(tools: ToolsDiff): void {
+  const total = tools.unchanged + tools.changed.length + tools.added.length + tools.removed.length;
+  if (total === 0) {
+    console.log("tools          none in either trace");
+    return;
+  }
+  const names = (list: string[]) =>
+    list.length > MAX_NAMES ? `${list.slice(0, MAX_NAMES).join(", ")}, ...` : list.join(", ");
+  const parts: string[] = [];
+  if (tools.added.length > 0) parts.push(`+${tools.added.length} added (${names(tools.added)})`);
+  if (tools.removed.length > 0) {
+    parts.push(`-${tools.removed.length} removed (${names(tools.removed)})`);
+  }
+  if (tools.changed.length > 0) {
+    parts.push(`${tools.changed.length} changed (${names(tools.changed)})`);
+  }
+  parts.push(`${tools.unchanged} unchanged`);
+  console.log(`tools          ${parts.join(" · ")}`);
+}

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -1,11 +1,11 @@
 import {
-  type ComparedMetric,
   compareTraces,
+  metricDelta,
+  metricValue,
   type PromptDiff,
   type ToolsDiff,
 } from "../../core/compare";
 import type { DiffLine } from "../../core/diff";
-import { formatCost, formatSeconds, formatTokens } from "../../core/format";
 import type { LoadedTrace } from "../load";
 import { printJson, table } from "../output";
 
@@ -38,7 +38,12 @@ export function compare(
   console.log(
     table(
       ["metric", "A", "B", "delta"],
-      comparison.metrics.map((m) => [m.key, value(m, m.a), value(m, m.b), delta(m)]),
+      comparison.metrics.map((m) => [
+        m.key,
+        metricValue(m.kind, m.a),
+        metricValue(m.kind, m.b),
+        metricDelta(m),
+      ]),
     ),
   );
   console.log("");
@@ -55,44 +60,13 @@ function side(loaded: LoadedTrace, label: string) {
   };
 }
 
-function value(metric: ComparedMetric, v: number): string {
-  switch (metric.kind) {
-    case "count":
-      return String(v);
-    case "tokens":
-      return formatTokens(v);
-    case "seconds":
-      return formatSeconds(v);
-    case "cost":
-      return formatCost(v);
-    case "share":
-      return `${Math.round(v * 100)}%`;
-  }
-}
-
-/** "-3 (-25%)" style delta, "pp" for share metrics, "=" when equal. */
-function delta(metric: ComparedMetric): string {
-  const d = metric.b - metric.a;
-  if (d === 0) return "=";
-  const sign = d > 0 ? "+" : "-";
-  const abs = Math.abs(d);
-  if (metric.kind === "share") {
-    const points = Math.round(abs * 100);
-    return points === 0 ? "=" : `${sign}${points}pp`;
-  }
-  const text = {
-    count: String(abs),
-    tokens: formatTokens(abs),
-    seconds: formatSeconds(abs),
-    cost: `$${abs.toFixed(4)}`,
-  }[metric.kind];
-  const relative = metric.a > 0 ? ` (${sign}${Math.round((abs / metric.a) * 100)}%)` : "";
-  return `${sign}${text}${relative}`;
-}
-
 function printPromptDiff(diff: PromptDiff): void {
   if (diff.same) {
-    console.log(`system prompt  identical (${diff.aChars} chars)`);
+    console.log(
+      diff.aChars === 0
+        ? "system prompt  none in either trace"
+        : `system prompt  identical (${diff.aChars} chars)`,
+    );
     return;
   }
   if (diff.lines === undefined) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,7 @@ Options:
   --json          machine-readable output, unbounded (summary, events, event, messages)
   --run <n|id>    scope a text command to one run of a multi-run source (see: runs);
                   compare takes it twice - first scopes A, second scopes B
+  --trajectory    compare only: aligned per-generation action table (* = diverged)
   --port <n>      server port (view default 4177; devtools default 4983)
   --no-open       start the server without opening a browser
   --role <r>      filter: system | user | assistant | tool-result | unknown
@@ -65,6 +66,7 @@ function main(): void {
     options: {
       json: { type: "boolean", default: false },
       run: { type: "string", multiple: true },
+      trajectory: { type: "boolean", default: false },
       port: { type: "string" },
       "no-open": { type: "boolean", default: false },
       all: { type: "boolean", default: false },
@@ -108,7 +110,10 @@ function main(): void {
     return;
   }
   if (command === "compare") {
-    compareCommand(paths, values.run ?? [], values.json);
+    compareCommand(paths, values.run ?? [], {
+      json: values.json,
+      trajectory: values.trajectory,
+    });
     return;
   }
 
@@ -152,7 +157,11 @@ function main(): void {
 }
 
 /** Resolves compare's A and B sides: two files, or one file with two --run selectors. */
-function compareCommand(paths: string[], runSelectors: string[], json: boolean): void {
+function compareCommand(
+  paths: string[],
+  runSelectors: string[],
+  options: { json: boolean; trajectory: boolean },
+): void {
   if (runSelectors.length > 2) fail("--run can be given at most twice for compare");
   const [pathA, pathB] = paths;
   const load = (path: string, selector: string | undefined) => ({
@@ -165,12 +174,12 @@ function compareCommand(paths: string[], runSelectors: string[], json: boolean):
     }
     const a = load(pathA!, runSelectors[0]);
     const b = load(pathA!, runSelectors[1]);
-    compare(a.loaded, b.loaded, { a: a.label, b: b.label }, json);
+    compare(a.loaded, b.loaded, { a: a.label, b: b.label }, options);
     return;
   }
   const a = load(pathA!, runSelectors[0]);
   const b = load(pathB, runSelectors[1]);
-  compare(a.loaded, b.loaded, { a: a.label, b: b.label }, json);
+  compare(a.loaded, b.loaded, { a: a.label, b: b.label }, options);
 }
 
 /** Bare `unbox-ai trace.json` opens the browser for humans, prints summary for pipes. */

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import type { MessageRole } from "../core/types";
+import { compare } from "./commands/compare";
 import { event } from "./commands/event";
 import { events } from "./commands/events";
 import { get } from "./commands/get";
@@ -27,10 +28,13 @@ Usage:
   unbox-ai tools <trace.json>            tool usage summary (--all for every call)
   unbox-ai messages <trace.json>         search messages (--role, --event, --grep, --limit)
   unbox-ai get <trace.json> <path>       raw value at a path, e.g. events[3].messages[2].content
+  unbox-ai compare <a.json> <b.json>     metric deltas + system prompt / tool diff between two
+                                         traces (one file, two runs: --run <x> --run <y>)
 
 Options:
   --json          machine-readable output, unbounded (summary, events, event, messages)
-  --run <n|id>    scope a text command to one run of a multi-run source (see: runs)
+  --run <n|id>    scope a text command to one run of a multi-run source (see: runs);
+                  compare takes it twice - first scopes A, second scopes B
   --port <n>      server port (view default 4177; devtools default 4983)
   --no-open       start the server without opening a browser
   --role <r>      filter: system | user | assistant | tool-result | unknown
@@ -51,6 +55,7 @@ const COMMANDS = new Set([
   "tools",
   "messages",
   "get",
+  "compare",
 ]);
 
 const ROLES: MessageRole[] = ["system", "user", "assistant", "tool-result", "unknown"];
@@ -59,7 +64,7 @@ function main(): void {
   const { values, positionals } = parseArgs({
     options: {
       json: { type: "boolean", default: false },
-      run: { type: "string" },
+      run: { type: "string", multiple: true },
       port: { type: "string" },
       "no-open": { type: "boolean", default: false },
       all: { type: "boolean", default: false },
@@ -102,9 +107,17 @@ function main(): void {
     runs(loadCollectionFiles(paths), values.json);
     return;
   }
+  if (command === "compare") {
+    compareCommand(paths, values.run ?? [], values.json);
+    return;
+  }
 
-  if (values.run !== undefined) setTraceRef(`<trace> --run ${values.run}`);
-  const loaded = values.run !== undefined ? loadRun(tracePath, values.run) : loadTrace(tracePath);
+  const run = values.run?.[0];
+  if (values.run !== undefined && values.run.length > 1) {
+    fail(`--run can be given once for ${command}; twice is for compare`);
+  }
+  if (run !== undefined) setTraceRef(`<trace> --run ${run}`);
+  const loaded = run !== undefined ? loadRun(tracePath, run) : loadTrace(tracePath);
 
   switch (command) {
     case "summary":
@@ -136,6 +149,28 @@ function main(): void {
       get(loaded, arg);
       return;
   }
+}
+
+/** Resolves compare's A and B sides: two files, or one file with two --run selectors. */
+function compareCommand(paths: string[], runSelectors: string[], json: boolean): void {
+  if (runSelectors.length > 2) fail("--run can be given at most twice for compare");
+  const [pathA, pathB] = paths;
+  const load = (path: string, selector: string | undefined) => ({
+    loaded: selector !== undefined ? loadRun(path, selector) : loadTrace(path),
+    label: selector !== undefined ? `${path} --run ${selector}` : path,
+  });
+  if (pathB === undefined) {
+    if (runSelectors.length !== 2) {
+      fail("compare needs two files, or one file with --run <x> --run <y> (see: runs)");
+    }
+    const a = load(pathA!, runSelectors[0]);
+    const b = load(pathA!, runSelectors[1]);
+    compare(a.loaded, b.loaded, { a: a.label, b: b.label }, json);
+    return;
+  }
+  const a = load(pathA!, runSelectors[0]);
+  const b = load(pathB, runSelectors[1]);
+  compare(a.loaded, b.loaded, { a: a.label, b: b.label }, json);
 }
 
 /** Bare `unbox-ai trace.json` opens the browser for humans, prints summary for pipes. */

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -164,21 +164,15 @@ function compareCommand(
 ): void {
   if (runSelectors.length > 2) fail("--run can be given at most twice for compare");
   const [pathA, pathB] = paths;
+  if (pathB === undefined && runSelectors.length !== 2) {
+    fail("compare needs two files, or one file with --run <x> --run <y> (see: runs)");
+  }
   const load = (path: string, selector: string | undefined) => ({
     loaded: selector !== undefined ? loadRun(path, selector) : loadTrace(path),
     label: selector !== undefined ? `${path} --run ${selector}` : path,
   });
-  if (pathB === undefined) {
-    if (runSelectors.length !== 2) {
-      fail("compare needs two files, or one file with --run <x> --run <y> (see: runs)");
-    }
-    const a = load(pathA!, runSelectors[0]);
-    const b = load(pathA!, runSelectors[1]);
-    compare(a.loaded, b.loaded, { a: a.label, b: b.label }, options);
-    return;
-  }
   const a = load(pathA!, runSelectors[0]);
-  const b = load(pathB, runSelectors[1]);
+  const b = load(pathB ?? pathA!, runSelectors[1]);
   compare(a.loaded, b.loaded, { a: a.label, b: b.label }, options);
 }
 

--- a/src/cli/server.test.ts
+++ b/src/cli/server.test.ts
@@ -57,6 +57,18 @@ describe("api routes", () => {
     expect(((await res.json()) as { value: string }).value).toBe("test-model");
   });
 
+  it("serves the addressed trace's tool definitions", async () => {
+    const tooled: RawTrace = {
+      ...raw,
+      events: [{ ...raw.events[0]!, available_tools: [{ type: "function", name: "search" }] }],
+    };
+    const { base } = await serve(staticSource([{ raw: tooled, trace: normalizeTrace(tooled) }]));
+    expect(await (await fetch(`${base}/api/tools`)).json()).toEqual({
+      tools: [{ type: "function", name: "search" }],
+    });
+    expect((await fetch(`${base}/api/tools?id=nope`)).status).toBe(404);
+  });
+
   it("serves the agent command, quoted and run-scoped as needed", async () => {
     const plain = await serve(
       staticSource([{ raw, trace: normalizeTrace(raw), sourcePath: "/tmp/trace.json" }]),

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { extname, join, normalize, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSummaries, type TraceCollectionItem } from "../core/collection";
+import { collectToolDefs } from "../core/compare";
 import { resolvePath } from "../core/path";
 
 const MIME: Record<string, string> = {
@@ -134,6 +135,14 @@ export async function startServer(
       const value = item && resolvePath(item.raw, url.searchParams.get("path") ?? "");
       res.writeHead(value === undefined ? 404 : 200, { "content-type": "application/json" });
       res.end(JSON.stringify(value === undefined ? { error: "nothing at path" } : { value }));
+      return;
+    }
+    if (url.pathname === "/api/tools") {
+      const item = pickTrace(source.current(), url);
+      res.writeHead(item ? 200 : 404, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify(item ? { tools: collectToolDefs(item.raw) } : { error: "no traces yet" }),
+      );
       return;
     }
     if (url.pathname === "/api/command") {

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compareTraces, pairTrajectory } from "./compare";
+import { collectToolDefs, compareTraces, pairTrajectory } from "./compare";
 import { diffLines } from "./diff";
 import { normalizeTrace } from "./normalize";
 import type { RawToolDef, RawTrace } from "./types";
@@ -39,7 +39,7 @@ function rawTrace(options: {
 }
 
 function side(raw: RawTrace) {
-  return { raw, trace: normalizeTrace(raw) };
+  return { trace: normalizeTrace(raw), tools: collectToolDefs(raw) };
 }
 
 describe("compareTraces", () => {
@@ -94,10 +94,11 @@ describe("compareTraces", () => {
       side(rawTrace({ id: "a", system: "you are helpful\nbe brief" })),
       side(rawTrace({ id: "b", system: "you are helpful\nbe thorough\nbe brief" })),
     );
-    expect(comparison.systemPrompt.same).toBe(false);
-    expect(comparison.systemPrompt.addedLines).toBe(1);
-    expect(comparison.systemPrompt.removedLines).toBe(0);
-    expect(comparison.systemPrompt.lines).toEqual([
+    const prompt = comparison.systemPrompt;
+    if (prompt.kind !== "differs") throw new Error(`expected a line diff, got ${prompt.kind}`);
+    expect(prompt.addedLines).toBe(1);
+    expect(prompt.removedLines).toBe(0);
+    expect(prompt.lines).toEqual([
       { kind: "same", text: "you are helpful" },
       { kind: "added", text: "be thorough" },
       { kind: "same", text: "be brief" },
@@ -109,8 +110,7 @@ describe("compareTraces", () => {
       side(rawTrace({ id: "a", system: "same" })),
       side(rawTrace({ id: "b", system: "same" })),
     );
-    expect(comparison.systemPrompt).toMatchObject({ same: true, addedLines: 0 });
-    expect(comparison.systemPrompt.lines).toBeUndefined();
+    expect(comparison.systemPrompt).toEqual({ kind: "identical", chars: 4 });
   });
 
   it("classifies tool definitions as added, removed, changed, unchanged", () => {
@@ -133,6 +133,15 @@ describe("compareTraces", () => {
       changed: ["edit"],
       unchanged: 1,
     });
+  });
+});
+
+describe("collectToolDefs", () => {
+  it("dedupes by name, a redefinition keeping the last one", () => {
+    const raw = rawTrace({ id: "a", events: 2 });
+    raw.events[0]!.available_tools = [{ type: "function", name: "search", description: "v1" }];
+    raw.events[1]!.available_tools = [{ type: "function", name: "search", description: "v2" }];
+    expect(collectToolDefs(raw)).toEqual([{ type: "function", name: "search", description: "v2" }]);
   });
 });
 

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -111,21 +111,24 @@ describe("compareTraces", () => {
 });
 
 describe("pairTrajectory", () => {
-  it("aligns by index, marks divergence and missing tails", () => {
-    const withTool = (id: string, events: number, tool?: string): RawTrace => {
-      const raw = rawTrace({ id, events });
-      if (tool !== undefined) {
-        raw.events[0]!.messages.push({
+  const sequence = (id: string, actions: (string | null)[]): RawTrace => {
+    const raw = rawTrace({ id, events: actions.length });
+    actions.forEach((tool, i) => {
+      if (tool !== null) {
+        raw.events[i]!.messages.push({
           role: "assistant",
           content: "",
-          tool_calls: [{ type: "function", id: "c1", function: { name: tool, arguments: {} } }],
+          tool_calls: [{ type: "function", id: `c${i}`, function: { name: tool, arguments: {} } }],
         });
       }
-      return raw;
-    };
+    });
+    return raw;
+  };
+
+  it("pairs mismatched actions as diverged and unmatched tails as one-sided", () => {
     const steps = pairTrajectory(
-      normalizeTrace(withTool("a", 2, "search")),
-      normalizeTrace(withTool("b", 3, "fetch")),
+      normalizeTrace(sequence("a", ["search", null])),
+      normalizeTrace(sequence("b", ["fetch", null, null])),
     );
     expect(steps).toHaveLength(3);
     expect(steps[0]!.diverged).toBe(true);
@@ -133,6 +136,19 @@ describe("pairTrajectory", () => {
     expect(steps[2]!.a).toBeUndefined();
     expect(steps[2]!.b).toBeDefined();
     expect(steps[2]!.diverged).toBe(false);
+  });
+
+  it("re-aligns after an extra step instead of cascading divergence", () => {
+    const steps = pairTrajectory(
+      normalizeTrace(sequence("a", ["nav", "extra", "click"])),
+      normalizeTrace(sequence("b", ["nav", "click"])),
+    );
+    expect(steps).toHaveLength(3);
+    expect(steps.map((s) => s.diverged)).toEqual([false, false, false]);
+    expect(steps[1]!.b).toBeUndefined();
+    // the click after the insertion pairs up despite the index offset
+    expect(steps[2]!.a?.index).toBe(2);
+    expect(steps[2]!.b?.index).toBe(1);
   });
 });
 

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { compareTraces } from "./compare";
+import { diffLines } from "./diff";
+import { normalizeTrace } from "./normalize";
+import type { RawToolDef, RawTrace } from "./types";
+
+function rawTrace(options: {
+  id: string;
+  system?: string;
+  tools?: RawToolDef[];
+  events?: number;
+  inputTokens?: number;
+  cost?: number;
+}): RawTrace {
+  const events = options.events ?? 1;
+  return {
+    trace_id: options.id,
+    timestamp: "2026-08-26T10:00:00.000Z",
+    name: options.id,
+    total_tokens: { input: (options.inputTokens ?? 10) * events, output: 5 * events },
+    total_cost: (options.cost ?? 0) * events,
+    events: Array.from({ length: events }, (_, i) => ({
+      type: "generation",
+      name: "agent",
+      model: "m",
+      provider: "p",
+      metrics: {
+        latency: 1,
+        tokens: { input: options.inputTokens ?? 10, output: 5 },
+        cost: options.cost ?? 0,
+      },
+      ...(options.tools !== undefined ? { available_tools: options.tools } : {}),
+      messages: [
+        ...(options.system !== undefined ? [{ role: "system", content: options.system }] : []),
+        { role: "user", content: `hi ${i}` },
+      ],
+    })),
+  };
+}
+
+function side(raw: RawTrace) {
+  return { raw, trace: normalizeTrace(raw) };
+}
+
+describe("compareTraces", () => {
+  it("computes headline metric deltas", () => {
+    const comparison = compareTraces(
+      side(rawTrace({ id: "a", events: 2, inputTokens: 100 })),
+      side(rawTrace({ id: "b", events: 3, inputTokens: 50 })),
+    );
+    const metric = (key: string) => comparison.metrics.find((m) => m.key === key)!;
+    expect(metric("generations")).toMatchObject({ a: 2, b: 3 });
+    expect(metric("input tokens")).toMatchObject({ a: 200, b: 150 });
+  });
+
+  it("hides the cost row when neither trace reports prices", () => {
+    const free = compareTraces(side(rawTrace({ id: "a" })), side(rawTrace({ id: "b" })));
+    expect(free.metrics.some((m) => m.key === "cost")).toBe(false);
+    const priced = compareTraces(
+      side(rawTrace({ id: "a", cost: 0.1 })),
+      side(rawTrace({ id: "b" })),
+    );
+    expect(priced.metrics.some((m) => m.key === "cost")).toBe(true);
+  });
+
+  it("diffs system prompts line by line", () => {
+    const comparison = compareTraces(
+      side(rawTrace({ id: "a", system: "you are helpful\nbe brief" })),
+      side(rawTrace({ id: "b", system: "you are helpful\nbe thorough\nbe brief" })),
+    );
+    expect(comparison.systemPrompt.same).toBe(false);
+    expect(comparison.systemPrompt.addedLines).toBe(1);
+    expect(comparison.systemPrompt.removedLines).toBe(0);
+    expect(comparison.systemPrompt.lines).toEqual([
+      { kind: "same", text: "you are helpful" },
+      { kind: "added", text: "be thorough" },
+      { kind: "same", text: "be brief" },
+    ]);
+  });
+
+  it("reports identical prompts without a diff", () => {
+    const comparison = compareTraces(
+      side(rawTrace({ id: "a", system: "same" })),
+      side(rawTrace({ id: "b", system: "same" })),
+    );
+    expect(comparison.systemPrompt).toMatchObject({ same: true, addedLines: 0 });
+    expect(comparison.systemPrompt.lines).toBeUndefined();
+  });
+
+  it("classifies tool definitions as added, removed, changed, unchanged", () => {
+    const tool = (name: string, description: string): RawToolDef => ({
+      type: "function",
+      name,
+      description,
+    });
+    const comparison = compareTraces(
+      side(
+        rawTrace({ id: "a", tools: [tool("keep", "k"), tool("edit", "old"), tool("drop", "d")] }),
+      ),
+      side(
+        rawTrace({ id: "b", tools: [tool("keep", "k"), tool("edit", "new"), tool("add", "a")] }),
+      ),
+    );
+    expect(comparison.tools).toEqual({
+      added: ["add"],
+      removed: ["drop"],
+      changed: ["edit"],
+      unchanged: 1,
+    });
+  });
+});
+
+describe("diffLines", () => {
+  it("interleaves removals and additions around common lines", () => {
+    expect(diffLines(["a", "b", "c"], ["a", "x", "c"])).toEqual([
+      { kind: "same", text: "a" },
+      { kind: "removed", text: "b" },
+      { kind: "added", text: "x" },
+      { kind: "same", text: "c" },
+    ]);
+  });
+
+  it("refuses pathologically large inputs instead of stalling", () => {
+    const big = Array.from({ length: 5000 }, (_, i) => `line ${i}`);
+    expect(diffLines(big, [...big].reverse())).toBeUndefined();
+  });
+});

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -53,6 +53,32 @@ describe("compareTraces", () => {
     expect(metric("input tokens")).toMatchObject({ a: 200, b: 150 });
   });
 
+  it("adds time-split rows only when the traces report the data", () => {
+    const timed: RawTrace = rawTrace({ id: "a" });
+    timed.events[0]!.metrics.latency = 5;
+    timed.events[0]!.metrics.time_to_first_token = 3;
+    timed.events[0]!.metrics.tokens.reasoning = 7;
+    timed.events[0]!.messages.push(
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ type: "function", id: "c1", function: { name: "wait", arguments: {} } }],
+      },
+      { role: "tool", tool_call_id: "c1", content: "done", duration_ms: 2000 },
+    );
+    const comparison = compareTraces(side(timed), side(timed));
+    const metric = (key: string) => comparison.metrics.find((m) => m.key === key);
+    expect(metric("prompt wait time")).toMatchObject({ a: 3, b: 3 });
+    expect(metric("output time")).toMatchObject({ a: 2, b: 2 });
+    expect(metric("tool time")).toMatchObject({ a: 2, b: 2 });
+    expect(metric("reasoning tokens")).toMatchObject({ a: 7, b: 7 });
+
+    const bare = compareTraces(side(rawTrace({ id: "a" })), side(rawTrace({ id: "b" })));
+    for (const key of ["prompt wait time", "output time", "tool time", "reasoning tokens"]) {
+      expect(bare.metrics.some((m) => m.key === key)).toBe(false);
+    }
+  });
+
   it("hides the cost row when neither trace reports prices", () => {
     const free = compareTraces(side(rawTrace({ id: "a" })), side(rawTrace({ id: "b" })));
     expect(free.metrics.some((m) => m.key === "cost")).toBe(false);

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compareTraces } from "./compare";
+import { compareTraces, pairTrajectory } from "./compare";
 import { diffLines } from "./diff";
 import { normalizeTrace } from "./normalize";
 import type { RawToolDef, RawTrace } from "./types";
@@ -107,6 +107,32 @@ describe("compareTraces", () => {
       changed: ["edit"],
       unchanged: 1,
     });
+  });
+});
+
+describe("pairTrajectory", () => {
+  it("aligns by index, marks divergence and missing tails", () => {
+    const withTool = (id: string, events: number, tool?: string): RawTrace => {
+      const raw = rawTrace({ id, events });
+      if (tool !== undefined) {
+        raw.events[0]!.messages.push({
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "c1", function: { name: tool, arguments: {} } }],
+        });
+      }
+      return raw;
+    };
+    const steps = pairTrajectory(
+      normalizeTrace(withTool("a", 2, "search")),
+      normalizeTrace(withTool("b", 3, "fetch")),
+    );
+    expect(steps).toHaveLength(3);
+    expect(steps[0]!.diverged).toBe(true);
+    expect(steps[1]!.diverged).toBe(false);
+    expect(steps[2]!.a).toBeUndefined();
+    expect(steps[2]!.b).toBeDefined();
+    expect(steps[2]!.diverged).toBe(false);
   });
 });
 

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -142,7 +142,6 @@ function defKey(def: RawToolDef): string {
 }
 
 export interface TrajectoryStep {
-  index: number;
   a?: Generation;
   b?: Generation;
   /** Both sides exist and took a different action (tool sequence or text-only). */
@@ -150,17 +149,47 @@ export interface TrajectoryStep {
 }
 
 /**
- * Pairs the runs' generations index by index - the honest v1 alignment.
- * A missing side marks the shorter run's tail; divergence marks steps
- * where the runs called different tools (or one answered in text).
+ * Aligns the runs' generations by action content (LCS over tool sequences),
+ * so an extra step in one run offsets nothing: matched steps pair up, and
+ * insertions show as one-sided rows. Runs of mismatches are zipped into
+ * diverged pairs. Falls back to index alignment on pathologically long runs.
  */
 export function pairTrajectory(a: NormalizedTrace, b: NormalizedTrace): TrajectoryStep[] {
+  const diff = diffLines(a.generations.map(actionKey), b.generations.map(actionKey));
+  if (diff === undefined) return pairByIndex(a, b);
+  const steps: TrajectoryStep[] = [];
+  let i = 0;
+  let j = 0;
+  let k = 0;
+  while (k < diff.length) {
+    if (diff[k]!.kind === "same") {
+      steps.push({ a: a.generations[i++]!, b: b.generations[j++]!, diverged: false });
+      k++;
+      continue;
+    }
+    const removed: Generation[] = [];
+    const added: Generation[] = [];
+    for (; k < diff.length && diff[k]!.kind !== "same"; k++) {
+      if (diff[k]!.kind === "removed") removed.push(a.generations[i++]!);
+      else added.push(b.generations[j++]!);
+    }
+    for (let r = 0; r < Math.max(removed.length, added.length); r++) {
+      steps.push({
+        ...(removed[r] !== undefined ? { a: removed[r] } : {}),
+        ...(added[r] !== undefined ? { b: added[r] } : {}),
+        diverged: removed[r] !== undefined && added[r] !== undefined,
+      });
+    }
+  }
+  return steps;
+}
+
+function pairByIndex(a: NormalizedTrace, b: NormalizedTrace): TrajectoryStep[] {
   const length = Math.max(a.generations.length, b.generations.length);
   return Array.from({ length }, (_, index) => {
     const genA = a.generations[index];
     const genB = b.generations[index];
     return {
-      index,
       ...(genA !== undefined ? { a: genA } : {}),
       ...(genB !== undefined ? { b: genB } : {}),
       diverged: genA !== undefined && genB !== undefined && actionKey(genA) !== actionKey(genB),

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,13 +1,13 @@
 import { type DiffLine, diffLines } from "./diff";
-import { formatCost, formatSeconds, formatTokens } from "./format";
+import { formatCallNames, formatCost, formatSeconds, formatTokens } from "./format";
 import { computeInsights, type Insights } from "./insights";
 import { allToolCalls, toolCallNames } from "./normalize";
 import type { Generation, NormalizedTrace, RawToolDef, RawTrace } from "./types";
 
-/** One side of a comparison: the normalized trace plus its raw form. */
+/** One side of a comparison: the normalized trace plus its tool definitions. */
 export interface ComparableTrace {
   trace: NormalizedTrace;
-  raw: RawTrace;
+  tools: RawToolDef[];
 }
 
 export type MetricKind = "count" | "tokens" | "seconds" | "cost" | "share";
@@ -19,15 +19,18 @@ export interface ComparedMetric {
   b: number;
 }
 
-export interface PromptDiff {
-  same: boolean;
-  aChars: number;
-  bChars: number;
-  addedLines: number;
-  removedLines: number;
-  /** Absent when identical, or when the prompts are too large to diff. */
-  lines?: DiffLine[];
-}
+export type PromptDiff =
+  | { kind: "identical"; chars: number }
+  /** The prompts differ but are too large to line-diff. */
+  | { kind: "too-large"; aChars: number; bChars: number }
+  | {
+      kind: "differs";
+      aChars: number;
+      bChars: number;
+      addedLines: number;
+      removedLines: number;
+      lines: DiffLine[];
+    };
 
 export interface ToolsDiff {
   added: string[];
@@ -50,82 +53,91 @@ export function compareTraces(a: ComparableTrace, b: ComparableTrace): TraceComp
     models: { a: a.trace.models, b: b.trace.models },
     metrics: compareMetrics(a.trace, b.trace),
     systemPrompt: comparePrompts(systemPrompt(a.trace), systemPrompt(b.trace)),
-    tools: compareTools(toolDefs(a.raw), toolDefs(b.raw)),
+    tools: compareTools(a.tools, b.tools),
   };
 }
 
-/** Rows that only exist when the traces report the data; hidden when both sides are 0. */
-const OPTIONAL_METRICS = new Set([
-  "cost",
-  "prompt wait time",
-  "output time",
-  "unattributed time",
-  "tool time",
-  "reasoning tokens",
-]);
+/** Everything the metric rows read, derived once per side. */
+interface SideStats {
+  trace: NormalizedTrace;
+  insights: Insights;
+  calls: ReturnType<typeof allToolCalls>;
+  /** ttft-attributed split of model time, summed across segments. */
+  time: { wait: number; output: number; unattributed: number };
+}
+
+function sideStats(trace: NormalizedTrace): SideStats {
+  const insights = computeInsights(trace);
+  const time = insights.perSegment.reduce(
+    (acc, segment) => ({
+      wait: acc.wait + segment.promptWait,
+      output: acc.output + segment.generation,
+      unattributed: acc.unattributed + segment.unattributed,
+    }),
+    { wait: 0, output: 0, unattributed: 0 },
+  );
+  return { trace, insights, calls: allToolCalls(trace), time };
+}
+
+/**
+ * The metrics table, one row per entry, both sides read through `of`.
+ * `optional` rows hide when neither trace reports the data (both 0);
+ * an `of` returning null (unreported) drops the row entirely.
+ */
+const METRIC_ROWS: {
+  key: string;
+  kind: MetricKind;
+  optional?: true;
+  of: (side: SideStats) => number | null;
+}[] = [
+  { key: "generations", kind: "count", of: (s) => s.trace.generations.length },
+  { key: "segments", kind: "count", of: (s) => s.trace.segmentCount },
+  { key: "input tokens", kind: "tokens", of: (s) => s.trace.totalTokens.input },
+  { key: "output tokens", kind: "tokens", of: (s) => s.trace.totalTokens.output },
+  {
+    key: "reasoning tokens",
+    kind: "tokens",
+    optional: true,
+    of: (s) =>
+      s.trace.generations.reduce((sum, gen) => sum + (gen.metrics.reasoningTokens ?? 0), 0),
+  },
+  { key: "model time", kind: "seconds", of: (s) => s.trace.totalLatency },
+  // ttft-attributed split of model time: waiting for the first token vs
+  // producing tokens (thinking included - traces carry no finer split)
+  { key: "prompt wait time", kind: "seconds", optional: true, of: (s) => s.time.wait },
+  { key: "output time", kind: "seconds", optional: true, of: (s) => s.time.output },
+  // generations that report no ttft (reasoning models often don't) land
+  // here - this is where hidden thinking time shows up
+  { key: "unattributed time", kind: "seconds", optional: true, of: (s) => s.time.unattributed },
+  {
+    key: "tool time",
+    kind: "seconds",
+    optional: true,
+    of: (s) => s.calls.reduce((ms, call) => ms + (call.durationMs ?? 0), 0) / 1000,
+  },
+  { key: "cost", kind: "cost", optional: true, of: (s) => s.trace.totalCost },
+  {
+    key: "cached prefix",
+    kind: "share",
+    of: (s) => (s.insights.inputTokens > 0 ? s.insights.cachedTokens / s.insights.inputTokens : 0),
+  },
+  { key: "tool calls", kind: "count", of: (s) => s.calls.length },
+  {
+    key: "tool failures",
+    kind: "count",
+    of: (s) => s.calls.filter((call) => call.success === false).length,
+  },
+  { key: "prompt wait", kind: "share", of: (s) => s.insights.promptWaitShare },
+];
 
 function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[] {
-  const ia = computeInsights(a);
-  const ib = computeInsights(b);
-  const callsA = allToolCalls(a);
-  const callsB = allToolCalls(b);
-  const failures = (calls: { success?: boolean }[]) =>
-    calls.filter((call) => call.success === false).length;
-  const toolSeconds = (calls: { durationMs?: number }[]) =>
-    calls.reduce((ms, call) => ms + (call.durationMs ?? 0), 0) / 1000;
-  const reasoning = (trace: NormalizedTrace) =>
-    trace.generations.reduce((sum, gen) => sum + (gen.metrics.reasoningTokens ?? 0), 0);
-  const modelTime = (insights: Insights) =>
-    insights.perSegment.reduce(
-      (acc, segment) => ({
-        wait: acc.wait + segment.promptWait,
-        output: acc.output + segment.generation,
-        unattributed: acc.unattributed + segment.unattributed,
-      }),
-      { wait: 0, output: 0, unattributed: 0 },
-    );
-  const share = (part: number, whole: number) => (whole > 0 ? part / whole : 0);
-  const timeA = modelTime(ia);
-  const timeB = modelTime(ib);
-  const metrics: ComparedMetric[] = [
-    { key: "generations", kind: "count", a: a.generations.length, b: b.generations.length },
-    { key: "segments", kind: "count", a: a.segmentCount, b: b.segmentCount },
-    { key: "input tokens", kind: "tokens", a: a.totalTokens.input, b: b.totalTokens.input },
-    { key: "output tokens", kind: "tokens", a: a.totalTokens.output, b: b.totalTokens.output },
-    { key: "reasoning tokens", kind: "tokens", a: reasoning(a), b: reasoning(b) },
-    { key: "model time", kind: "seconds", a: a.totalLatency, b: b.totalLatency },
-    // ttft-attributed split of model time: waiting for the first token vs
-    // producing tokens (thinking included - traces carry no finer split)
-    { key: "prompt wait time", kind: "seconds", a: timeA.wait, b: timeB.wait },
-    { key: "output time", kind: "seconds", a: timeA.output, b: timeB.output },
-    // generations that report no ttft (reasoning models often don't) land
-    // here - this is where hidden thinking time shows up
-    {
-      key: "unattributed time",
-      kind: "seconds",
-      a: timeA.unattributed,
-      b: timeB.unattributed,
-    },
-    { key: "tool time", kind: "seconds", a: toolSeconds(callsA), b: toolSeconds(callsB) },
-    { key: "cost", kind: "cost", a: a.totalCost, b: b.totalCost },
-    {
-      key: "cached prefix",
-      kind: "share",
-      a: share(ia.cachedTokens, ia.inputTokens),
-      b: share(ib.cachedTokens, ib.inputTokens),
-    },
-    { key: "tool calls", kind: "count", a: callsA.length, b: callsB.length },
-    { key: "tool failures", kind: "count", a: failures(callsA), b: failures(callsB) },
-  ];
-  if (ia.promptWaitShare !== null && ib.promptWaitShare !== null) {
-    metrics.push({
-      key: "prompt wait",
-      kind: "share",
-      a: ia.promptWaitShare,
-      b: ib.promptWaitShare,
-    });
-  }
-  return metrics.filter((m) => !OPTIONAL_METRICS.has(m.key) || m.a > 0 || m.b > 0);
+  const [sa, sb] = [sideStats(a), sideStats(b)];
+  return METRIC_ROWS.flatMap((row) => {
+    const [va, vb] = [row.of(sa), row.of(sb)];
+    if (va === null || vb === null) return [];
+    if (row.optional && va <= 0 && vb <= 0) return [];
+    return [{ key: row.key, kind: row.kind, a: va, b: vb }];
+  });
 }
 
 /** The run's system prompt: system messages of the first generation. */
@@ -137,30 +149,32 @@ function systemPrompt(trace: NormalizedTrace): string {
 }
 
 function comparePrompts(a: string, b: string): PromptDiff {
-  if (a === b) {
-    return { same: true, aChars: a.length, bChars: b.length, addedLines: 0, removedLines: 0 };
-  }
+  if (a === b) return { kind: "identical", chars: a.length };
   const lines = diffLines(a.split("\n"), b.split("\n"));
+  if (lines === undefined) return { kind: "too-large", aChars: a.length, bChars: b.length };
   return {
-    same: false,
+    kind: "differs",
     aChars: a.length,
     bChars: b.length,
-    addedLines: lines?.filter((line) => line.kind === "added").length ?? 0,
-    removedLines: lines?.filter((line) => line.kind === "removed").length ?? 0,
-    ...(lines !== undefined ? { lines } : {}),
+    addedLines: lines.filter((line) => line.kind === "added").length,
+    removedLines: lines.filter((line) => line.kind === "removed").length,
+    lines,
   };
 }
 
-/** Tool definitions by name across all events; a redefinition keeps the last one. */
-function toolDefs(raw: RawTrace): Map<string, RawToolDef> {
+/** Tool definitions across all events, deduped by name; a redefinition keeps the last one. */
+export function collectToolDefs(raw: RawTrace): RawToolDef[] {
   const defs = new Map<string, RawToolDef>();
   for (const event of raw.events) {
     for (const def of event.available_tools ?? []) defs.set(def.name, def);
   }
-  return defs;
+  return [...defs.values()];
 }
 
-function compareTools(a: Map<string, RawToolDef>, b: Map<string, RawToolDef>): ToolsDiff {
+function compareTools(defsA: RawToolDef[], defsB: RawToolDef[]): ToolsDiff {
+  const byName = (defs: RawToolDef[]) => new Map(defs.map((def) => [def.name, def]));
+  const a = byName(defsA);
+  const b = byName(defsB);
   const added: string[] = [];
   const removed: string[] = [];
   const changed: string[] = [];
@@ -239,6 +253,27 @@ function pairByIndex(a: NormalizedTrace, b: NormalizedTrace): TrajectoryStep[] {
 export function actionKey(gen: Generation): string {
   const tools = toolCallNames(gen);
   return tools.length > 0 ? tools.join(",") : "text";
+}
+
+/** True when the runs differ at this step: a diverged pair or a one-sided row. */
+export function stepDiffers(step: TrajectoryStep): boolean {
+  return step.diverged || step.a === undefined || step.b === undefined;
+}
+
+/** "12" when both sides sit at the same generation, else "a12/b13" style. */
+export function stepIndexLabel(step: TrajectoryStep): string {
+  if (step.a !== undefined && step.b !== undefined) {
+    return step.a.index === step.b.index
+      ? String(step.a.index)
+      : `a${step.a.index}/b${step.b.index}`;
+  }
+  return step.a !== undefined ? `a${step.a.index}` : `b${step.b!.index}`;
+}
+
+/** One line of what a generation did: its tool calls, or the reply clipped to maxChars. */
+export function stepAction(gen: Generation, maxChars: number): string {
+  const calls = formatCallNames(toolCallNames(gen));
+  return calls !== "" ? calls : `-> ${(gen.newMessages.at(-1)?.text ?? "").slice(0, maxChars)}`;
 }
 
 /** One metric value rendered for its kind, shared by the CLI table and the viewer. */

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -59,6 +59,7 @@ const OPTIONAL_METRICS = new Set([
   "cost",
   "prompt wait time",
   "output time",
+  "unattributed time",
   "tool time",
   "reasoning tokens",
 ]);
@@ -79,8 +80,9 @@ function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[
       (acc, segment) => ({
         wait: acc.wait + segment.promptWait,
         output: acc.output + segment.generation,
+        unattributed: acc.unattributed + segment.unattributed,
       }),
-      { wait: 0, output: 0 },
+      { wait: 0, output: 0, unattributed: 0 },
     );
   const share = (part: number, whole: number) => (whole > 0 ? part / whole : 0);
   const timeA = modelTime(ia);
@@ -96,6 +98,14 @@ function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[
     // producing tokens (thinking included - traces carry no finer split)
     { key: "prompt wait time", kind: "seconds", a: timeA.wait, b: timeB.wait },
     { key: "output time", kind: "seconds", a: timeA.output, b: timeB.output },
+    // generations that report no ttft (reasoning models often don't) land
+    // here - this is where hidden thinking time shows up
+    {
+      key: "unattributed time",
+      kind: "seconds",
+      a: timeA.unattributed,
+      b: timeB.unattributed,
+    },
     { key: "tool time", kind: "seconds", a: toolSeconds(callsA), b: toolSeconds(callsB) },
     { key: "cost", kind: "cost", a: a.totalCost, b: b.totalCost },
     {

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,8 +1,8 @@
 import { type DiffLine, diffLines } from "./diff";
 import { formatCost, formatSeconds, formatTokens } from "./format";
 import { computeInsights } from "./insights";
-import { allToolCalls } from "./normalize";
-import type { NormalizedTrace, RawToolDef, RawTrace } from "./types";
+import { allToolCalls, toolCallNames } from "./normalize";
+import type { Generation, NormalizedTrace, RawToolDef, RawTrace } from "./types";
 
 /** One side of a comparison: the normalized trace plus its raw form. */
 export interface ComparableTrace {
@@ -139,6 +139,39 @@ function compareTools(a: Map<string, RawToolDef>, b: Map<string, RawToolDef>): T
 
 function defKey(def: RawToolDef): string {
   return JSON.stringify({ description: def.description, inputSchema: def.inputSchema });
+}
+
+export interface TrajectoryStep {
+  index: number;
+  a?: Generation;
+  b?: Generation;
+  /** Both sides exist and took a different action (tool sequence or text-only). */
+  diverged: boolean;
+}
+
+/**
+ * Pairs the runs' generations index by index - the honest v1 alignment.
+ * A missing side marks the shorter run's tail; divergence marks steps
+ * where the runs called different tools (or one answered in text).
+ */
+export function pairTrajectory(a: NormalizedTrace, b: NormalizedTrace): TrajectoryStep[] {
+  const length = Math.max(a.generations.length, b.generations.length);
+  return Array.from({ length }, (_, index) => {
+    const genA = a.generations[index];
+    const genB = b.generations[index];
+    return {
+      index,
+      ...(genA !== undefined ? { a: genA } : {}),
+      ...(genB !== undefined ? { b: genB } : {}),
+      diverged: genA !== undefined && genB !== undefined && actionKey(genA) !== actionKey(genB),
+    };
+  });
+}
+
+/** What a generation did: its tool calls in order, or a plain text response. */
+export function actionKey(gen: Generation): string {
+  const tools = toolCallNames(gen);
+  return tools.length > 0 ? tools.join(",") : "text";
 }
 
 /** One metric value rendered for its kind, shared by the CLI table and the viewer. */

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,0 +1,141 @@
+import { type DiffLine, diffLines } from "./diff";
+import { computeInsights } from "./insights";
+import { allToolCalls } from "./normalize";
+import type { NormalizedTrace, RawToolDef, RawTrace } from "./types";
+
+/** One side of a comparison: the normalized trace plus its raw form. */
+export interface ComparableTrace {
+  trace: NormalizedTrace;
+  raw: RawTrace;
+}
+
+export type MetricKind = "count" | "tokens" | "seconds" | "cost" | "share";
+
+export interface ComparedMetric {
+  key: string;
+  kind: MetricKind;
+  a: number;
+  b: number;
+}
+
+export interface PromptDiff {
+  same: boolean;
+  aChars: number;
+  bChars: number;
+  addedLines: number;
+  removedLines: number;
+  /** Absent when identical, or when the prompts are too large to diff. */
+  lines?: DiffLine[];
+}
+
+export interface ToolsDiff {
+  added: string[];
+  removed: string[];
+  /** Same name, different description or input schema. */
+  changed: string[];
+  unchanged: number;
+}
+
+export interface TraceComparison {
+  models: { a: string[]; b: string[] };
+  metrics: ComparedMetric[];
+  systemPrompt: PromptDiff;
+  tools: ToolsDiff;
+}
+
+/** Diffs two traces: headline metric deltas plus system prompt and tool-set changes. */
+export function compareTraces(a: ComparableTrace, b: ComparableTrace): TraceComparison {
+  return {
+    models: { a: a.trace.models, b: b.trace.models },
+    metrics: compareMetrics(a.trace, b.trace),
+    systemPrompt: comparePrompts(systemPrompt(a.trace), systemPrompt(b.trace)),
+    tools: compareTools(toolDefs(a.raw), toolDefs(b.raw)),
+  };
+}
+
+function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[] {
+  const ia = computeInsights(a);
+  const ib = computeInsights(b);
+  const callsA = allToolCalls(a);
+  const callsB = allToolCalls(b);
+  const failures = (calls: { success?: boolean }[]) =>
+    calls.filter((call) => call.success === false).length;
+  const share = (part: number, whole: number) => (whole > 0 ? part / whole : 0);
+  const metrics: ComparedMetric[] = [
+    { key: "generations", kind: "count", a: a.generations.length, b: b.generations.length },
+    { key: "segments", kind: "count", a: a.segmentCount, b: b.segmentCount },
+    { key: "input tokens", kind: "tokens", a: a.totalTokens.input, b: b.totalTokens.input },
+    { key: "output tokens", kind: "tokens", a: a.totalTokens.output, b: b.totalTokens.output },
+    { key: "model time", kind: "seconds", a: a.totalLatency, b: b.totalLatency },
+    { key: "cost", kind: "cost", a: a.totalCost, b: b.totalCost },
+    {
+      key: "cached prefix",
+      kind: "share",
+      a: share(ia.cachedTokens, ia.inputTokens),
+      b: share(ib.cachedTokens, ib.inputTokens),
+    },
+    { key: "tool calls", kind: "count", a: callsA.length, b: callsB.length },
+    { key: "tool failures", kind: "count", a: failures(callsA), b: failures(callsB) },
+  ];
+  if (ia.promptWaitShare !== null && ib.promptWaitShare !== null) {
+    metrics.push({
+      key: "prompt wait",
+      kind: "share",
+      a: ia.promptWaitShare,
+      b: ib.promptWaitShare,
+    });
+  }
+  // traces without price data report 0; a delta of nothing is noise
+  return metrics.filter((m) => m.key !== "cost" || m.a > 0 || m.b > 0);
+}
+
+/** The run's system prompt: system messages of the first generation. */
+function systemPrompt(trace: NormalizedTrace): string {
+  return (trace.generations[0]?.newMessages ?? [])
+    .filter((message) => message.role === "system")
+    .map((message) => message.text)
+    .join("\n");
+}
+
+function comparePrompts(a: string, b: string): PromptDiff {
+  if (a === b) {
+    return { same: true, aChars: a.length, bChars: b.length, addedLines: 0, removedLines: 0 };
+  }
+  const lines = diffLines(a.split("\n"), b.split("\n"));
+  return {
+    same: false,
+    aChars: a.length,
+    bChars: b.length,
+    addedLines: lines?.filter((line) => line.kind === "added").length ?? 0,
+    removedLines: lines?.filter((line) => line.kind === "removed").length ?? 0,
+    ...(lines !== undefined ? { lines } : {}),
+  };
+}
+
+/** Tool definitions by name across all events; a redefinition keeps the last one. */
+function toolDefs(raw: RawTrace): Map<string, RawToolDef> {
+  const defs = new Map<string, RawToolDef>();
+  for (const event of raw.events) {
+    for (const def of event.available_tools ?? []) defs.set(def.name, def);
+  }
+  return defs;
+}
+
+function compareTools(a: Map<string, RawToolDef>, b: Map<string, RawToolDef>): ToolsDiff {
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+  let unchanged = 0;
+  for (const name of a.keys()) if (!b.has(name)) removed.push(name);
+  for (const [name, def] of b) {
+    const other = a.get(name);
+    if (other === undefined) added.push(name);
+    else if (defKey(other) !== defKey(def)) changed.push(name);
+    else unchanged++;
+  }
+  return { added, removed, changed, unchanged };
+}
+
+function defKey(def: RawToolDef): string {
+  return JSON.stringify({ description: def.description, inputSchema: def.inputSchema });
+}

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,4 +1,5 @@
 import { type DiffLine, diffLines } from "./diff";
+import { formatCost, formatSeconds, formatTokens } from "./format";
 import { computeInsights } from "./insights";
 import { allToolCalls } from "./normalize";
 import type { NormalizedTrace, RawToolDef, RawTrace } from "./types";
@@ -138,4 +139,40 @@ function compareTools(a: Map<string, RawToolDef>, b: Map<string, RawToolDef>): T
 
 function defKey(def: RawToolDef): string {
   return JSON.stringify({ description: def.description, inputSchema: def.inputSchema });
+}
+
+/** One metric value rendered for its kind, shared by the CLI table and the viewer. */
+export function metricValue(kind: MetricKind, v: number): string {
+  switch (kind) {
+    case "count":
+      return String(v);
+    case "tokens":
+      return formatTokens(v);
+    case "seconds":
+      return formatSeconds(v);
+    case "cost":
+      return formatCost(v);
+    case "share":
+      return `${Math.round(v * 100)}%`;
+  }
+}
+
+/** "-3 (-25%)" style delta, "pp" for share metrics, "=" when equal. */
+export function metricDelta(metric: ComparedMetric): string {
+  const d = metric.b - metric.a;
+  if (d === 0) return "=";
+  const sign = d > 0 ? "+" : "-";
+  const abs = Math.abs(d);
+  if (metric.kind === "share") {
+    const points = Math.round(abs * 100);
+    return points === 0 ? "=" : `${sign}${points}pp`;
+  }
+  const text = {
+    count: String(abs),
+    tokens: formatTokens(abs),
+    seconds: formatSeconds(abs),
+    cost: `$${abs.toFixed(4)}`,
+  }[metric.kind];
+  const relative = metric.a > 0 ? ` (${sign}${Math.round((abs / metric.a) * 100)}%)` : "";
+  return `${sign}${text}${relative}`;
 }

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -1,6 +1,6 @@
 import { type DiffLine, diffLines } from "./diff";
 import { formatCost, formatSeconds, formatTokens } from "./format";
-import { computeInsights } from "./insights";
+import { computeInsights, type Insights } from "./insights";
 import { allToolCalls, toolCallNames } from "./normalize";
 import type { Generation, NormalizedTrace, RawToolDef, RawTrace } from "./types";
 
@@ -54,6 +54,15 @@ export function compareTraces(a: ComparableTrace, b: ComparableTrace): TraceComp
   };
 }
 
+/** Rows that only exist when the traces report the data; hidden when both sides are 0. */
+const OPTIONAL_METRICS = new Set([
+  "cost",
+  "prompt wait time",
+  "output time",
+  "tool time",
+  "reasoning tokens",
+]);
+
 function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[] {
   const ia = computeInsights(a);
   const ib = computeInsights(b);
@@ -61,13 +70,33 @@ function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[
   const callsB = allToolCalls(b);
   const failures = (calls: { success?: boolean }[]) =>
     calls.filter((call) => call.success === false).length;
+  const toolSeconds = (calls: { durationMs?: number }[]) =>
+    calls.reduce((ms, call) => ms + (call.durationMs ?? 0), 0) / 1000;
+  const reasoning = (trace: NormalizedTrace) =>
+    trace.generations.reduce((sum, gen) => sum + (gen.metrics.reasoningTokens ?? 0), 0);
+  const modelTime = (insights: Insights) =>
+    insights.perSegment.reduce(
+      (acc, segment) => ({
+        wait: acc.wait + segment.promptWait,
+        output: acc.output + segment.generation,
+      }),
+      { wait: 0, output: 0 },
+    );
   const share = (part: number, whole: number) => (whole > 0 ? part / whole : 0);
+  const timeA = modelTime(ia);
+  const timeB = modelTime(ib);
   const metrics: ComparedMetric[] = [
     { key: "generations", kind: "count", a: a.generations.length, b: b.generations.length },
     { key: "segments", kind: "count", a: a.segmentCount, b: b.segmentCount },
     { key: "input tokens", kind: "tokens", a: a.totalTokens.input, b: b.totalTokens.input },
     { key: "output tokens", kind: "tokens", a: a.totalTokens.output, b: b.totalTokens.output },
+    { key: "reasoning tokens", kind: "tokens", a: reasoning(a), b: reasoning(b) },
     { key: "model time", kind: "seconds", a: a.totalLatency, b: b.totalLatency },
+    // ttft-attributed split of model time: waiting for the first token vs
+    // producing tokens (thinking included - traces carry no finer split)
+    { key: "prompt wait time", kind: "seconds", a: timeA.wait, b: timeB.wait },
+    { key: "output time", kind: "seconds", a: timeA.output, b: timeB.output },
+    { key: "tool time", kind: "seconds", a: toolSeconds(callsA), b: toolSeconds(callsB) },
     { key: "cost", kind: "cost", a: a.totalCost, b: b.totalCost },
     {
       key: "cached prefix",
@@ -86,8 +115,7 @@ function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[
       b: ib.promptWaitShare,
     });
   }
-  // traces without price data report 0; a delta of nothing is noise
-  return metrics.filter((m) => m.key !== "cost" || m.a > 0 || m.b > 0);
+  return metrics.filter((m) => !OPTIONAL_METRICS.has(m.key) || m.a > 0 || m.b > 0);
 }
 
 /** The run's system prompt: system messages of the first generation. */

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -1,0 +1,44 @@
+export interface DiffLine {
+  kind: "same" | "added" | "removed";
+  text: string;
+}
+
+/** DP-table cells above which diffing is skipped (~64MB of Int32 rows). */
+const MAX_CELLS = 16_000_000;
+
+/**
+ * Classic LCS line diff: removed lines come from `a`, added from `b`.
+ * Returns undefined for pathologically large inputs instead of stalling.
+ */
+export function diffLines(a: string[], b: string[]): DiffLine[] | undefined {
+  if ((a.length + 1) * (b.length + 1) > MAX_CELLS) return undefined;
+  const width = b.length + 1;
+  const lcs = new Int32Array((a.length + 1) * width);
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i * width + j] =
+        a[i] === b[j]
+          ? lcs[(i + 1) * width + j + 1]! + 1
+          : Math.max(lcs[(i + 1) * width + j]!, lcs[i * width + j + 1]!);
+    }
+  }
+  const lines: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      lines.push({ kind: "same", text: a[i]! });
+      i++;
+      j++;
+    } else if (lcs[(i + 1) * width + j]! >= lcs[i * width + j + 1]!) {
+      lines.push({ kind: "removed", text: a[i]! });
+      i++;
+    } else {
+      lines.push({ kind: "added", text: b[j]! });
+      j++;
+    }
+  }
+  for (; i < a.length; i++) lines.push({ kind: "removed", text: a[i]! });
+  for (; j < b.length; j++) lines.push({ kind: "added", text: b[j]! });
+  return lines;
+}

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -1,6 +1,7 @@
 import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
 import { useEffect, useRef, useState } from "react";
+import { CompareDialog } from "@/components/CompareDialog";
 import { GenerationDetail } from "@/components/GenerationDetail";
 import { Header } from "@/components/Header";
 import { ReplayBar } from "@/components/ReplayBar";
@@ -113,6 +114,7 @@ function Loaded({
   onSelect,
 }: LoadedProps) {
   const replay = useReplay(trace);
+  const [comparing, setComparing] = useState(false);
 
   // several opened files become tabs; devtools' live feed stays a plain list
   const tabs = live ? [] : sourceTabs(runs);
@@ -164,8 +166,16 @@ function Loaded({
       <Header
         trace={trace}
         agentCommand={agentCommand}
+        onCompare={runs.length > 1 ? () => setComparing(true) : undefined}
         onClear={live ? () => void fetch("/api/clear", { method: "POST" }) : undefined}
       />
+      {comparing && (
+        <CompareDialog
+          runs={runs}
+          initialA={selectedRun ?? trace.traceId}
+          onClose={() => setComparing(false)}
+        />
+      )}
       {tabs.length > 0 && (
         <SourceTabs
           tabs={tabs}

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -1,7 +1,7 @@
 import type { RunSummary } from "@core/collection";
 import type { NormalizedTrace } from "@core/types";
 import { useEffect, useRef, useState } from "react";
-import { CompareDialog } from "@/components/CompareDialog";
+import { CompareView } from "@/components/CompareView";
 import { GenerationDetail } from "@/components/GenerationDetail";
 import { Header } from "@/components/Header";
 import { ReplayBar } from "@/components/ReplayBar";
@@ -13,6 +13,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { Waterfall } from "@/components/Waterfall";
 import { useReplay } from "@/lib/use-replay";
 import { useTrace } from "@/lib/use-trace";
+import { cn } from "@/lib/utils";
 
 export function App() {
   const {
@@ -166,17 +167,18 @@ function Loaded({
       <Header
         trace={trace}
         agentCommand={agentCommand}
-        onCompare={runs.length > 1 ? () => setComparing(true) : undefined}
+        onCompare={runs.length > 1 ? () => setComparing((v) => !v) : undefined}
+        comparing={comparing}
         onClear={live ? () => void fetch("/api/clear", { method: "POST" }) : undefined}
       />
       {comparing && (
-        <CompareDialog
+        <CompareView
           runs={runs}
           initialA={selectedRun ?? trace.traceId}
           onClose={() => setComparing(false)}
         />
       )}
-      {tabs.length > 0 && (
+      {!comparing && tabs.length > 0 && (
         <SourceTabs
           tabs={tabs}
           selectedSource={selectedSource}
@@ -186,7 +188,7 @@ function Loaded({
           openError={openError}
         />
       )}
-      <div className="flex min-h-0 flex-1">
+      <div className={cn("flex min-h-0 flex-1", comparing && "hidden")}>
         {/* stable gutters: a scrollbar appearing mid-stream must not shift the layout */}
         <aside className="w-80 shrink-0 overflow-y-auto border-r border-ta-grey-400 [scrollbar-gutter:stable]">
           {scopedRuns.length > 1 && (

--- a/src/viewer/components/CompareDialog.tsx
+++ b/src/viewer/components/CompareDialog.tsx
@@ -1,0 +1,252 @@
+import type { RunSummary } from "@core/collection";
+import {
+  type ComparableTrace,
+  compareTraces,
+  metricDelta,
+  metricValue,
+  type TraceComparison,
+} from "@core/compare";
+import type { NormalizedTrace, RawTrace } from "@core/types";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { localTraceItem } from "@/lib/use-trace";
+import { cn } from "@/lib/utils";
+
+interface CompareDialogProps {
+  runs: RunSummary[];
+  /** Run preselected as side A, normally the one on screen. */
+  initialA: string;
+  onClose: () => void;
+}
+
+/** A/B comparison of two runs: metric deltas, system prompt diff, tool-set diff. */
+export function CompareDialog({ runs, initialA, onClose }: CompareDialogProps) {
+  const [aId, setAId] = useState(initialA);
+  const [bId, setBId] = useState(
+    () => (runs.find((run) => run.id !== initialA) ?? runs[0])?.id ?? initialA,
+  );
+  const [comparison, setComparison] = useState<TraceComparison>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let stale = false;
+    setComparison(undefined);
+    setError(undefined);
+    Promise.all([loadSide(aId), loadSide(bId)])
+      .then(([a, b]) => {
+        if (!stale) setComparison(compareTraces(a, b));
+      })
+      .catch((cause) => {
+        if (!stale) setError(String(cause));
+      });
+    return () => {
+      stale = true;
+    };
+  }, [aId, bId]);
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <div className="flex items-center gap-3 border-b border-ta-grey-400 px-5 py-3">
+          <DialogTitle>compare runs</DialogTitle>
+          <DialogClose render={<Button className="ml-auto border-none">close</Button>} />
+        </div>
+        <div className="flex min-h-0 flex-col gap-5 overflow-y-auto px-5 py-4">
+          <div className="flex items-center gap-3">
+            <RunSelect side="A" runs={runs} value={aId} onChange={setAId} />
+            <span className="type-accent-s text-ta-grey-300">vs</span>
+            <RunSelect side="B" runs={runs} value={bId} onChange={setBId} />
+          </div>
+          {error && <p className="type-body-s text-ta-error">Failed to compare: {error}</p>}
+          {!error && !comparison && (
+            <p className="type-accent-s text-ta-grey-200">loading runs...</p>
+          )}
+          {comparison && <Comparison comparison={comparison} />}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RunSelect({
+  side,
+  runs,
+  value,
+  onChange,
+}: {
+  side: string;
+  runs: RunSummary[];
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <label className="type-accent-s flex min-w-0 flex-1 items-center gap-2 text-ta-grey-200">
+      {side}
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="min-w-0 flex-1 cursor-pointer border border-ta-grey-400 bg-ta-grey-450 px-2 py-1.5 text-ta-sand-50"
+      >
+        {runs.map((run) => (
+          <option key={run.id} value={run.id}>
+            {runLabel(run)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/** "file.json · run name" so cross-file picks stay legible. */
+function runLabel(run: RunSummary): string {
+  const base = run.source?.split(/[\\/]/).filter(Boolean).at(-1);
+  return base !== undefined ? `${base} · ${run.name}` : run.name;
+}
+
+function Comparison({ comparison }: { comparison: TraceComparison }) {
+  const { models, metrics, systemPrompt, tools } = comparison;
+  const sameModels = models.a.join(", ") === models.b.join(", ");
+  return (
+    <>
+      <p className="type-accent-s text-ta-grey-200">
+        models{" "}
+        <span className="text-ta-sand-50">
+          {sameModels
+            ? models.a.join(", ")
+            : `A: ${models.a.join(", ")}  B: ${models.b.join(", ")}`}
+        </span>
+      </p>
+      <div className="type-accent-s grid grid-cols-[1fr_auto_auto_auto] gap-x-6 gap-y-1.5">
+        <HeaderCell>metric</HeaderCell>
+        <HeaderCell right>A</HeaderCell>
+        <HeaderCell right>B</HeaderCell>
+        <HeaderCell right>delta</HeaderCell>
+        {metrics.map((m) => {
+          const delta = metricDelta(m);
+          return (
+            <div key={m.key} className="contents">
+              <span className="text-ta-grey-200">{m.key}</span>
+              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.a)}</span>
+              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.b)}</span>
+              <span
+                className={cn("text-right", delta === "=" ? "text-ta-grey-300" : "text-ta-sand-50")}
+              >
+                {delta}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <PromptSection prompt={systemPrompt} />
+      <ToolsSection tools={tools} />
+    </>
+  );
+}
+
+function HeaderCell({ children, right }: { children: React.ReactNode; right?: boolean }) {
+  return <span className={cn("text-ta-grey-300", right && "text-right")}>{children}</span>;
+}
+
+/** Full diff is rendered; the dialog body scrolls. */
+const MAX_RENDERED_DIFF_LINES = 600;
+
+function PromptSection({ prompt }: { prompt: TraceComparison["systemPrompt"] }) {
+  if (prompt.same) {
+    return (
+      <Section label="system prompt">
+        <p className="type-body-s text-ta-grey-200">
+          {prompt.aChars === 0 ? "none in either run" : `identical (${prompt.aChars} chars)`}
+        </p>
+      </Section>
+    );
+  }
+  if (prompt.lines === undefined) {
+    return (
+      <Section label="system prompt">
+        <p className="type-body-s text-ta-grey-200">
+          differs (A {prompt.aChars} chars, B {prompt.bChars} chars - too large to line-diff)
+        </p>
+      </Section>
+    );
+  }
+  const lines = prompt.lines.slice(0, MAX_RENDERED_DIFF_LINES);
+  return (
+    <Section label={`system prompt · +${prompt.addedLines} / -${prompt.removedLines} lines`}>
+      <div className="type-body-s overflow-x-auto whitespace-pre border border-ta-grey-400 bg-ta-grey-450 px-3 py-2 font-(family-name:--font-dm-mono) leading-relaxed">
+        {lines.map((line, i) => (
+          <div
+            // diff lines have no identity beyond their position
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional list
+            key={i}
+            className={cn(
+              line.kind === "added" && "bg-ta-orange-300/10 text-ta-orange-75",
+              line.kind === "removed" && "bg-ta-error/10 text-ta-error",
+              line.kind === "same" && "text-ta-grey-200",
+            )}
+          >
+            {line.kind === "added" ? "+ " : line.kind === "removed" ? "- " : "  "}
+            {line.text}
+          </div>
+        ))}
+        {prompt.lines.length > lines.length && (
+          <div className="text-ta-grey-300">
+            [... {prompt.lines.length - lines.length} more lines]
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+function ToolsSection({ tools }: { tools: TraceComparison["tools"] }) {
+  const total = tools.unchanged + tools.changed.length + tools.added.length + tools.removed.length;
+  return (
+    <Section label="tools">
+      {total === 0 ? (
+        <p className="type-body-s text-ta-grey-200">none in either run</p>
+      ) : (
+        <div className="type-body-s flex flex-col gap-1">
+          {tools.added.length > 0 && (
+            <p className="text-ta-orange-75">+ added: {tools.added.join(", ")}</p>
+          )}
+          {tools.removed.length > 0 && (
+            <p className="text-ta-error">- removed: {tools.removed.join(", ")}</p>
+          )}
+          {tools.changed.length > 0 && (
+            <p className="text-ta-sand-50">changed: {tools.changed.join(", ")}</p>
+          )}
+          <p className="text-ta-grey-200">{tools.unchanged} unchanged</p>
+        </div>
+      )}
+    </Section>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="type-accent-s text-ta-grey-200">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+/** A run's trace + raw, from local memory for browser-opened files, else the server. */
+async function loadSide(id: string): Promise<ComparableTrace> {
+  const local = localTraceItem(id);
+  if (local !== undefined) return local;
+  const [trace, raw] = await Promise.all([
+    fetchJson(`/api/trace?id=${encodeURIComponent(id)}`) as Promise<NormalizedTrace>,
+    (fetchJson(`/api/raw?id=${encodeURIComponent(id)}&path=`) as Promise<{ value: RawTrace }>).then(
+      (body) => body.value,
+    ),
+  ]);
+  return { trace, raw };
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
+  return res.json();
+}

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -4,38 +4,45 @@ import {
   compareTraces,
   metricDelta,
   metricValue,
+  pairTrajectory,
   type TraceComparison,
+  type TrajectoryStep,
 } from "@core/compare";
-import type { NormalizedTrace, RawTrace } from "@core/types";
-import { useEffect, useState } from "react";
+import { formatCallNames, formatSeconds, formatTokens } from "@core/format";
+import { toolCallNames } from "@core/normalize";
+import type { Generation, NormalizedTrace, RawTrace } from "@core/types";
+import { useEffect, useMemo, useState } from "react";
+import { MessageCard } from "@/components/MessageCard";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { localTraceItem } from "@/lib/use-trace";
 import { cn } from "@/lib/utils";
 
-interface CompareDialogProps {
+interface CompareViewProps {
   runs: RunSummary[];
   /** Run preselected as side A, normally the one on screen. */
   initialA: string;
   onClose: () => void;
 }
 
-/** A/B comparison of two runs: metric deltas, system prompt diff, tool-set diff. */
-export function CompareDialog({ runs, initialA, onClose }: CompareDialogProps) {
+/**
+ * Full-pane A/B exploration: aligned per-generation trajectory with
+ * expandable message detail, headline deltas, prompt and tool diffs.
+ */
+export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
   const [aId, setAId] = useState(initialA);
   const [bId, setBId] = useState(
     () => (runs.find((run) => run.id !== initialA) ?? runs[0])?.id ?? initialA,
   );
-  const [comparison, setComparison] = useState<TraceComparison>();
+  const [sides, setSides] = useState<{ a: ComparableTrace; b: ComparableTrace }>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
     let stale = false;
-    setComparison(undefined);
+    setSides(undefined);
     setError(undefined);
     Promise.all([loadSide(aId), loadSide(bId)])
       .then(([a, b]) => {
-        if (!stale) setComparison(compareTraces(a, b));
+        if (!stale) setSides({ a, b });
       })
       .catch((cause) => {
         if (!stale) setError(String(cause));
@@ -45,27 +52,40 @@ export function CompareDialog({ runs, initialA, onClose }: CompareDialogProps) {
     };
   }, [aId, bId]);
 
+  const comparison = useMemo(
+    () => (sides !== undefined ? compareTraces(sides.a, sides.b) : undefined),
+    [sides],
+  );
+  const steps = useMemo(
+    () => (sides !== undefined ? pairTrajectory(sides.a.trace, sides.b.trace) : undefined),
+    [sides],
+  );
+
   return (
-    <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent>
-        <div className="flex items-center gap-3 border-b border-ta-grey-400 px-5 py-3">
-          <DialogTitle>compare runs</DialogTitle>
-          <DialogClose render={<Button className="ml-auto border-none">close</Button>} />
-        </div>
-        <div className="flex min-h-0 flex-col gap-5 overflow-y-auto px-5 py-4">
-          <div className="flex items-center gap-3">
-            <RunSelect side="A" runs={runs} value={aId} onChange={setAId} />
-            <span className="type-accent-s text-ta-grey-300">vs</span>
-            <RunSelect side="B" runs={runs} value={bId} onChange={setBId} />
-          </div>
-          {error && <p className="type-body-s text-ta-error">Failed to compare: {error}</p>}
-          {!error && !comparison && (
-            <p className="type-accent-s text-ta-grey-200">loading runs...</p>
-          )}
-          {comparison && <Comparison comparison={comparison} />}
-        </div>
-      </DialogContent>
-    </Dialog>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-3 border-b border-ta-grey-400 px-6 py-3">
+        <RunSelect side="A" runs={runs} value={aId} onChange={setAId} />
+        <span className="type-accent-s shrink-0 text-ta-grey-300">vs</span>
+        <RunSelect side="B" runs={runs} value={bId} onChange={setBId} />
+        <Button className="shrink-0" onClick={onClose}>
+          close
+        </Button>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-5 [scrollbar-gutter:stable]">
+        {error && <p className="type-body-s text-ta-error">Failed to compare: {error}</p>}
+        {!error && comparison === undefined && (
+          <p className="type-accent-s text-ta-grey-200">loading runs...</p>
+        )}
+        {comparison && steps && (
+          <>
+            <MetricsGrid comparison={comparison} />
+            <Trajectory steps={steps} />
+            <PromptSection prompt={comparison.systemPrompt} />
+            <ToolsSection tools={comparison.tools} />
+          </>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -104,20 +124,18 @@ function runLabel(run: RunSummary): string {
   return base !== undefined ? `${base} · ${run.name}` : run.name;
 }
 
-function Comparison({ comparison }: { comparison: TraceComparison }) {
-  const { models, metrics, systemPrompt, tools } = comparison;
+function MetricsGrid({ comparison }: { comparison: TraceComparison }) {
+  const { models, metrics } = comparison;
   const sameModels = models.a.join(", ") === models.b.join(", ");
   return (
-    <>
-      <p className="type-accent-s text-ta-grey-200">
-        models{" "}
-        <span className="text-ta-sand-50">
-          {sameModels
-            ? models.a.join(", ")
-            : `A: ${models.a.join(", ")}  B: ${models.b.join(", ")}`}
-        </span>
-      </p>
-      <div className="type-accent-s grid grid-cols-[1fr_auto_auto_auto] gap-x-6 gap-y-1.5">
+    <Section
+      label={
+        sameModels
+          ? `totals · ${models.a.join(", ")}`
+          : `totals · A: ${models.a.join(", ")} · B: ${models.b.join(", ")}`
+      }
+    >
+      <div className="type-accent-s grid max-w-2xl grid-cols-[1fr_auto_auto_auto] gap-x-8 gap-y-1.5">
         <HeaderCell>metric</HeaderCell>
         <HeaderCell right>A</HeaderCell>
         <HeaderCell right>B</HeaderCell>
@@ -138,9 +156,7 @@ function Comparison({ comparison }: { comparison: TraceComparison }) {
           );
         })}
       </div>
-      <PromptSection prompt={systemPrompt} />
-      <ToolsSection tools={tools} />
-    </>
+    </Section>
   );
 }
 
@@ -148,7 +164,101 @@ function HeaderCell({ children, right }: { children: React.ReactNode; right?: bo
   return <span className={cn("text-ta-grey-300", right && "text-right")}>{children}</span>;
 }
 
-/** Full diff is rendered; the dialog body scrolls. */
+const ROW_GRID = "grid grid-cols-[3rem_1fr_1fr] gap-x-4";
+
+function Trajectory({ steps }: { steps: TrajectoryStep[] }) {
+  const [expanded, setExpanded] = useState<number>();
+  const firstDifference = steps.find(
+    (step) => step.diverged || step.a === undefined || step.b === undefined,
+  )?.index;
+  return (
+    <Section
+      label={
+        firstDifference === undefined
+          ? "trajectory · aligned by generation · same actions throughout"
+          : `trajectory · aligned by generation · differs from [${firstDifference}]`
+      }
+    >
+      <div className="border border-ta-grey-400">
+        <div
+          className={cn(
+            ROW_GRID,
+            "type-accent-s border-b border-ta-grey-400 px-4 py-2 text-ta-grey-300",
+          )}
+        >
+          <span>gen</span>
+          <span>A</span>
+          <span>B</span>
+        </div>
+        {steps.map((step) => (
+          <div key={step.index} className="border-b border-ta-grey-400 last:border-b-0">
+            <button
+              type="button"
+              onClick={() => setExpanded(expanded === step.index ? undefined : step.index)}
+              aria-expanded={expanded === step.index}
+              className={cn(
+                ROW_GRID,
+                "type-accent-s w-full cursor-pointer px-4 py-2 text-left transition-colors hover:bg-ta-grey-450",
+                expanded === step.index && "bg-ta-grey-450",
+              )}
+            >
+              <span className={step.diverged ? "text-ta-orange-300" : "text-ta-grey-300"}>
+                {step.index}
+                {step.diverged && " *"}
+              </span>
+              <GenCell gen={step.a} diverged={step.diverged} />
+              <GenCell gen={step.b} diverged={step.diverged} />
+            </button>
+            {expanded === step.index && (
+              <div
+                className={cn(ROW_GRID, "border-t border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3")}
+              >
+                <span />
+                <GenDetail gen={step.a} />
+                <GenDetail gen={step.b} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+}
+
+function GenCell({ gen, diverged }: { gen?: Generation; diverged: boolean }) {
+  if (gen === undefined) return <span className="text-ta-grey-300">-</span>;
+  const calls = formatCallNames(toolCallNames(gen));
+  const doing = calls !== "" ? calls : `-> ${(gen.newMessages.at(-1)?.text ?? "").slice(0, 80)}`;
+  return (
+    <span className="flex min-w-0 items-baseline gap-3">
+      <span className={cn("min-w-0 truncate", diverged ? "text-ta-orange-75" : "text-ta-grey-100")}>
+        {doing}
+      </span>
+      <span className="ml-auto shrink-0 text-ta-grey-300">
+        {formatTokens(gen.metrics.inputTokens)} in · {formatSeconds(gen.metrics.latency)}
+      </span>
+    </span>
+  );
+}
+
+/** One side's new messages for the expanded generation. */
+function GenDetail({ gen }: { gen?: Generation }) {
+  if (gen === undefined) {
+    return <p className="type-accent-s text-ta-grey-300">no generation on this side</p>;
+  }
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {gen.newMessages.map((message) => (
+        <MessageCard key={message.index} message={message} />
+      ))}
+      {gen.newMessages.length === 0 && (
+        <p className="type-accent-s text-ta-grey-300">no new messages</p>
+      )}
+    </div>
+  );
+}
+
+/** Full diff is rendered; the pane scrolls. */
 const MAX_RENDERED_DIFF_LINES = 600;
 
 function PromptSection({ prompt }: { prompt: TraceComparison["systemPrompt"] }) {

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -136,70 +136,80 @@ function MetricsGrid({ comparison }: { comparison: TraceComparison }) {
           : `totals · A: ${models.a.join(", ")} · B: ${models.b.join(", ")}`
       }
     >
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
-        {metrics.map((m) => (
-          <MetricTile key={m.key} metric={m} />
-        ))}
-      </div>
+      <DeltaChart metrics={metrics} />
     </Section>
   );
 }
 
-/** One headline metric as a stat tile: name, prominent delta, A/B bars and values. */
-function MetricTile({ metric }: { metric: ComparedMetric }) {
-  const delta = metricDelta(metric);
+/**
+ * Diverging bar per metric: B relative to A around a shared zero line, all
+ * rows on one scale (the largest |delta|, capped at 100%) so the metric that
+ * moved most sticks out and near-equal runs read as bars hugging zero.
+ * Position encodes direction; the printed delta is the exact value.
+ */
+function DeltaChart({ metrics }: { metrics: ComparedMetric[] }) {
+  const rows = metrics.map((m) => ({ m, rel: relativeDelta(m) }));
+  const scale = Math.max(...rows.map((row) => Math.abs(row.rel)), 0.01);
   return (
-    <div className="flex flex-col gap-2.5 border border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3">
-      <div className="flex items-baseline justify-between gap-3">
-        <span className="type-accent-s text-ta-grey-200">{metric.key}</span>
-        <span
-          className={cn("type-accent-m", delta === "=" ? "text-ta-grey-300" : "text-ta-sand-50")}
-        >
-          {delta}
-        </span>
-      </div>
-      <MetricBars metric={metric} />
-      <div className="type-accent-s flex justify-between gap-3 text-ta-grey-100">
-        <span>
-          <SeriesChip className="bg-ta-grey-300" /> A {metricValue(metric.kind, metric.a)}
-        </span>
-        <span>
-          <SeriesChip className="bg-ta-orange-300" /> B {metricValue(metric.kind, metric.b)}
-        </span>
+    <div className="border border-ta-grey-400 px-5 py-4">
+      <div className="type-accent-s grid grid-cols-[minmax(7rem,auto)_minmax(4.5rem,auto)_1fr_minmax(4.5rem,auto)_minmax(7rem,auto)] items-center gap-x-5 gap-y-2">
+        <span className="text-ta-grey-300">metric</span>
+        <span className="text-right text-ta-grey-300">A</span>
+        <span className="text-center text-ta-grey-300">B vs A · scale ±{pct(scale)}</span>
+        <span className="text-ta-grey-300">B</span>
+        <span className="text-right text-ta-grey-300">delta</span>
+        {rows.map(({ m, rel }) => {
+          const delta = metricDelta(m);
+          return (
+            <div key={m.key} className="contents">
+              <span className="text-ta-grey-200">{m.key}</span>
+              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.a)}</span>
+              <DeltaBar rel={rel} scale={scale} />
+              <span className="text-ta-grey-100">{metricValue(m.kind, m.b)}</span>
+              <span
+                className={cn("text-right", delta === "=" ? "text-ta-grey-300" : "text-ta-sand-50")}
+              >
+                {delta}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
-}
-
-/** Ties a bar's series color to its value column. */
-function SeriesChip({ className }: { className: string }) {
-  return <span aria-hidden className={cn("mr-1 inline-block size-1.5 align-middle", className)} />;
 }
 
 /**
- * Paired A/B bars per metric. Each row scales to its own max - tokens,
- * dollars, and seconds share no axis - except shares, which scale to 100%
- * so the bar length is the honest ratio. A is the neutral reference, B the
- * accent; identity is also carried by position and the labeled columns.
+ * B's change relative to A: (b-a)/a for magnitudes (capped at +-100%, the
+ * printed delta carries the exact number), plain point difference for
+ * shares, +100% when A is zero and B is not.
  */
-function MetricBars({ metric }: { metric: ComparedMetric }) {
-  const scale = metric.kind === "share" ? 1 : Math.max(metric.a, metric.b);
-  const width = (v: number) => (scale <= 0 || v <= 0 ? "0%" : `${Math.max((v / scale) * 100, 2)}%`);
-  return (
-    <div
-      className="flex min-w-16 flex-col gap-0.5"
-      title={`A ${metricValue(metric.kind, metric.a)} · B ${metricValue(metric.kind, metric.b)}`}
-    >
-      <Bar className="bg-ta-grey-300" width={width(metric.a)} />
-      <Bar className="bg-ta-orange-300" width={width(metric.b)} />
-    </div>
-  );
+function relativeDelta(metric: ComparedMetric): number {
+  if (metric.kind === "share") return metric.b - metric.a;
+  if (metric.a > 0) return Math.max(Math.min((metric.b - metric.a) / metric.a, 1), -1);
+  return metric.b > 0 ? 1 : 0;
 }
 
-function Bar({ className, width }: { className: string; width: string }) {
+function pct(fraction: number): string {
+  const points = fraction * 100;
+  return `${points >= 10 ? Math.round(points) : Math.round(points * 10) / 10}%`;
+}
+
+function DeltaBar({ rel, scale }: { rel: number; scale: number }) {
+  const half = Math.min((Math.abs(rel) / scale) * 50, 50);
+  const width = rel === 0 ? 0 : Math.max(half, 0.75);
   return (
-    <div className="h-[5px] w-full bg-ta-grey-450">
-      <div className={cn("h-full", className)} style={{ width }} />
+    <div className="relative h-3 w-full bg-ta-grey-450/60">
+      <span aria-hidden className="absolute inset-y-0 left-1/2 w-px bg-ta-grey-300" />
+      {width > 0 && (
+        <span
+          aria-hidden
+          className="absolute inset-y-[3px] bg-ta-orange-300"
+          style={
+            rel > 0 ? { left: "50%", width: `${width}%` } : { right: "50%", width: `${width}%` }
+          }
+        />
+      )}
     </div>
   );
 }

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -164,77 +164,89 @@ function MetricsGrid({ comparison, labels }: { comparison: TraceComparison; labe
           : `totals · ${labels.a}: ${models.a.join(", ")} · ${labels.b}: ${models.b.join(", ")}`
       }
     >
-      <DeltaChart metrics={metrics} labels={labels} />
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
+        {metrics.map((m) => (
+          <MetricTile key={m.key} metric={m} labels={labels} />
+        ))}
+      </div>
     </Section>
   );
 }
 
 /**
- * One row per metric, read left to right like a sentence: value went from A
- * to B, changed by this much, and the bar is the size of that change. Bars
- * share one scale (largest |change|, capped at 100%) and are magnitude-only;
- * the arrow carries the direction.
+ * One metric per tile, the change as the hero: a big percent with an arrow,
+ * "from -> to" under it, and a small per-tile pair of bars for proportion.
+ * Unchanged metrics dim so the moved ones carry the panel.
  */
-function DeltaChart({ metrics, labels }: { metrics: ComparedMetric[]; labels: SideLabels }) {
-  const rows = metrics.map((m) => ({ m, rel: relativeDelta(m) }));
-  const scale = Math.max(...rows.map((row) => Math.abs(row.rel)), 0.01);
+function MetricTile({ metric, labels }: { metric: ComparedMetric; labels: SideLabels }) {
+  const delta = metricDelta(metric);
+  const equal = delta === "=";
   return (
-    <div className="border border-ta-grey-400 px-5 py-4">
-      <div className="type-accent-s grid grid-cols-[minmax(8rem,auto)_minmax(5.5rem,auto)_minmax(5.5rem,auto)_minmax(10rem,auto)_1fr] items-center gap-x-6 gap-y-2">
-        <span className="text-ta-grey-300">metric</span>
-        <span className="truncate text-right text-ta-grey-300">{labels.a}</span>
-        <span className="truncate text-right text-ta-grey-300">{labels.b}</span>
-        <span className="text-right text-ta-grey-300">change</span>
-        <span className="text-ta-grey-300">size of change</span>
-        {rows.map(({ m, rel }) => {
-          const delta = metricDelta(m);
-          return (
-            <div key={m.key} className="contents">
-              <span className="text-ta-grey-200">{m.key}</span>
-              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.a)}</span>
-              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.b)}</span>
-              <span
-                className={cn("text-right", rel === 0 ? "text-ta-grey-300" : "text-ta-sand-50")}
-              >
-                {rel !== 0 && (
-                  <span aria-hidden className="text-ta-orange-300">
-                    {rel > 0 ? "▲ " : "▼ "}
-                  </span>
-                )}
-                {delta}
-              </span>
-              <MagnitudeBar rel={rel} scale={scale} />
-            </div>
-          );
-        })}
-      </div>
+    <div
+      className={cn(
+        "flex flex-col gap-2.5 border border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3",
+        equal && "opacity-55",
+      )}
+      title={`${metric.key}: ${delta}`}
+    >
+      <span className="type-accent-s text-ta-grey-200">{metric.key}</span>
+      <span className="font-(family-name:--font-dm-mono) text-2xl leading-none tracking-wide text-ta-sand-50">
+        {equal ? (
+          <span className="text-ta-grey-300">=</span>
+        ) : (
+          <>
+            <span aria-hidden className="text-ta-orange-300">
+              {metric.b > metric.a ? "▲" : "▼"}
+            </span>{" "}
+            {heroDelta(metric)}
+          </>
+        )}
+      </span>
+      <span className="type-accent-s text-ta-grey-200">
+        {metricValue(metric.kind, metric.a)} <span className="text-ta-grey-300">-&gt;</span>{" "}
+        {metricValue(metric.kind, metric.b)}
+      </span>
+      <PairBars metric={metric} labels={labels} />
     </div>
   );
 }
 
-/**
- * B's change relative to A: (b-a)/a for magnitudes (capped at +-100%, the
- * printed delta carries the exact number), plain point difference for
- * shares, +100% when A is zero and B is not.
- */
-function relativeDelta(metric: ComparedMetric): number {
-  if (metric.kind === "share") return metric.b - metric.a;
-  if (metric.a > 0) return Math.max(Math.min((metric.b - metric.a) / metric.a, 1), -1);
-  return metric.b > 0 ? 1 : 0;
+/** The tile's headline: relative change when A gives a base, else absolute. */
+function heroDelta(metric: ComparedMetric): string {
+  const abs = Math.abs(metric.b - metric.a);
+  if (metric.kind === "share") return `${Math.round(abs * 100)}pp`;
+  if (metric.a > 0) {
+    const percent = Math.round((abs / metric.a) * 100);
+    return percent === 0 ? "<1%" : `${percent}%`;
+  }
+  return metricValue(metric.kind, abs);
 }
 
-/** Left-anchored |change| bar; direction lives in the row's arrow, not here. */
-function MagnitudeBar({ rel, scale }: { rel: number; scale: number }) {
-  const width = rel === 0 ? 0 : Math.max(Math.min((Math.abs(rel) / scale) * 100, 100), 1);
+/** Both runs' magnitudes on the tile's own scale; shares scale to 100%. */
+function PairBars({ metric, labels }: { metric: ComparedMetric; labels: SideLabels }) {
+  const scale = metric.kind === "share" ? 1 : Math.max(metric.a, metric.b);
+  const width = (v: number) => (scale <= 0 || v <= 0 ? 0 : Math.max((v / scale) * 100, 1.5));
   return (
-    <div className="relative h-3 w-full max-w-2xl bg-ta-grey-450/60">
-      {width > 0 && (
-        <span
-          aria-hidden
-          className="absolute inset-y-[3px] left-0 bg-ta-orange-300"
-          style={{ width: `${width}%` }}
-        />
-      )}
+    <div className="flex flex-col gap-1">
+      <PairBar label={labels.a} color="bg-ta-grey-300" width={width(metric.a)} />
+      <PairBar label={labels.b} color="bg-ta-orange-300" width={width(metric.b)} />
+    </div>
+  );
+}
+
+function PairBar({ label, color, width }: { label: string; color: string; width: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="type-accent-s w-16 shrink-0 truncate text-ta-grey-300">{label}</span>
+      <div className="relative h-2 flex-1 bg-ta-grey-450">
+        {width > 0 && (
+          <span
+            aria-hidden
+            className={cn("absolute inset-y-0 left-0", color)}
+            style={{ width: `${width}%` }}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -164,19 +164,19 @@ function HeaderCell({ children, right }: { children: React.ReactNode; right?: bo
   return <span className={cn("text-ta-grey-300", right && "text-right")}>{children}</span>;
 }
 
-const ROW_GRID = "grid grid-cols-[3rem_1fr_1fr] gap-x-4";
+const ROW_GRID = "grid grid-cols-[4.5rem_1fr_1fr] gap-x-4";
 
 function Trajectory({ steps }: { steps: TrajectoryStep[] }) {
   const [expanded, setExpanded] = useState<number>();
-  const firstDifference = steps.find(
+  const different = steps.filter(
     (step) => step.diverged || step.a === undefined || step.b === undefined,
-  )?.index;
+  );
   return (
     <Section
       label={
-        firstDifference === undefined
-          ? "trajectory · aligned by generation · same actions throughout"
-          : `trajectory · aligned by generation · differs from [${firstDifference}]`
+        different.length === 0
+          ? "trajectory · aligned by action · same actions throughout"
+          : `trajectory · aligned by action · differs at ${different.length} of ${steps.length} steps`
       }
     >
       <div className="border border-ta-grey-400">
@@ -190,39 +190,58 @@ function Trajectory({ steps }: { steps: TrajectoryStep[] }) {
           <span>A</span>
           <span>B</span>
         </div>
-        {steps.map((step) => (
-          <div key={step.index} className="border-b border-ta-grey-400 last:border-b-0">
-            <button
-              type="button"
-              onClick={() => setExpanded(expanded === step.index ? undefined : step.index)}
-              aria-expanded={expanded === step.index}
-              className={cn(
-                ROW_GRID,
-                "type-accent-s w-full cursor-pointer px-4 py-2 text-left transition-colors hover:bg-ta-grey-450",
-                expanded === step.index && "bg-ta-grey-450",
-              )}
+        {steps.map((step, row) => {
+          const differs = step.diverged || step.a === undefined || step.b === undefined;
+          return (
+            <div
+              key={`${step.a?.index ?? "-"}:${step.b?.index ?? "-"}`}
+              className="border-b border-ta-grey-400 last:border-b-0"
             >
-              <span className={step.diverged ? "text-ta-orange-300" : "text-ta-grey-300"}>
-                {step.index}
-                {step.diverged && " *"}
-              </span>
-              <GenCell gen={step.a} diverged={step.diverged} />
-              <GenCell gen={step.b} diverged={step.diverged} />
-            </button>
-            {expanded === step.index && (
-              <div
-                className={cn(ROW_GRID, "border-t border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3")}
+              <button
+                type="button"
+                onClick={() => setExpanded(expanded === row ? undefined : row)}
+                aria-expanded={expanded === row}
+                className={cn(
+                  ROW_GRID,
+                  "type-accent-s w-full cursor-pointer px-4 py-2 text-left transition-colors hover:bg-ta-grey-450",
+                  expanded === row && "bg-ta-grey-450",
+                )}
               >
-                <span />
-                <GenDetail gen={step.a} />
-                <GenDetail gen={step.b} />
-              </div>
-            )}
-          </div>
-        ))}
+                <span className={differs ? "text-ta-orange-300" : "text-ta-grey-300"}>
+                  {stepIndexLabel(step)}
+                  {differs && " *"}
+                </span>
+                <GenCell gen={step.a} diverged={step.diverged} />
+                <GenCell gen={step.b} diverged={step.diverged} />
+              </button>
+              {expanded === row && (
+                <div
+                  className={cn(
+                    ROW_GRID,
+                    "border-t border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3",
+                  )}
+                >
+                  <span />
+                  <GenDetail gen={step.a} />
+                  <GenDetail gen={step.b} />
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </Section>
   );
+}
+
+/** "12" when both sides sit at the same generation, else "a12/b13" style. */
+function stepIndexLabel(step: TrajectoryStep): string {
+  if (step.a !== undefined && step.b !== undefined) {
+    return step.a.index === step.b.index
+      ? String(step.a.index)
+      : `a${step.a.index}/b${step.b.index}`;
+  }
+  return step.a !== undefined ? `a${step.a.index}` : `b${step.b!.index}`;
 }
 
 function GenCell({ gen, diverged }: { gen?: Generation; diverged: boolean }) {

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -62,11 +62,22 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
     [sides],
   );
 
+  const labels = { a: shortLabel(runs, aId), b: shortLabel(runs, bId) };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-3 border-b border-ta-grey-400 px-6 py-3">
         <RunSelect side="A" runs={runs} value={aId} onChange={setAId} />
-        <span className="type-accent-s shrink-0 text-ta-grey-300">vs</span>
+        <Button
+          className="shrink-0"
+          title="swap sides"
+          onClick={() => {
+            setAId(bId);
+            setBId(aId);
+          }}
+        >
+          swap
+        </Button>
         <RunSelect side="B" runs={runs} value={bId} onChange={setBId} />
         <Button className="shrink-0" onClick={onClose}>
           close
@@ -79,8 +90,8 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
         )}
         {comparison && steps && (
           <>
-            <MetricsGrid comparison={comparison} />
-            <Trajectory steps={steps} />
+            <MetricsGrid comparison={comparison} labels={labels} />
+            <Trajectory steps={steps} labels={labels} />
             <PromptSection prompt={comparison.systemPrompt} />
             <ToolsSection tools={comparison.tools} />
           </>
@@ -88,6 +99,18 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
       </div>
     </div>
   );
+}
+
+/** A short, human name for a side: file basename without the trace suffix. */
+function shortLabel(runs: RunSummary[], id: string): string {
+  const run = runs.find((r) => r.id === id);
+  const base = run?.source
+    ?.split(/[\\/]/)
+    .filter(Boolean)
+    .at(-1)
+    ?.replace(/\.trace\.json$|\.json$/, "");
+  const label = base ?? run?.name ?? id;
+  return label.length > 16 ? `${label.slice(0, 15)}…` : label;
 }
 
 function RunSelect({
@@ -125,7 +148,12 @@ function runLabel(run: RunSummary): string {
   return base !== undefined ? `${base} · ${run.name}` : run.name;
 }
 
-function MetricsGrid({ comparison }: { comparison: TraceComparison }) {
+interface SideLabels {
+  a: string;
+  b: string;
+}
+
+function MetricsGrid({ comparison, labels }: { comparison: TraceComparison; labels: SideLabels }) {
   const { models, metrics } = comparison;
   const sameModels = models.a.join(", ") === models.b.join(", ");
   return (
@@ -133,44 +161,49 @@ function MetricsGrid({ comparison }: { comparison: TraceComparison }) {
       label={
         sameModels
           ? `totals · ${models.a.join(", ")}`
-          : `totals · A: ${models.a.join(", ")} · B: ${models.b.join(", ")}`
+          : `totals · ${labels.a}: ${models.a.join(", ")} · ${labels.b}: ${models.b.join(", ")}`
       }
     >
-      <DeltaChart metrics={metrics} />
+      <DeltaChart metrics={metrics} labels={labels} />
     </Section>
   );
 }
 
 /**
- * Diverging bar per metric: B relative to A around a shared zero line, all
- * rows on one scale (the largest |delta|, capped at 100%) so the metric that
- * moved most sticks out and near-equal runs read as bars hugging zero.
- * Position encodes direction; the printed delta is the exact value.
+ * One row per metric, read left to right like a sentence: value went from A
+ * to B, changed by this much, and the bar is the size of that change. Bars
+ * share one scale (largest |change|, capped at 100%) and are magnitude-only;
+ * the arrow carries the direction.
  */
-function DeltaChart({ metrics }: { metrics: ComparedMetric[] }) {
+function DeltaChart({ metrics, labels }: { metrics: ComparedMetric[]; labels: SideLabels }) {
   const rows = metrics.map((m) => ({ m, rel: relativeDelta(m) }));
   const scale = Math.max(...rows.map((row) => Math.abs(row.rel)), 0.01);
   return (
     <div className="border border-ta-grey-400 px-5 py-4">
-      <div className="type-accent-s grid grid-cols-[minmax(7rem,auto)_minmax(4.5rem,auto)_1fr_minmax(4.5rem,auto)_minmax(7rem,auto)] items-center gap-x-5 gap-y-2">
+      <div className="type-accent-s grid grid-cols-[minmax(8rem,auto)_minmax(5.5rem,auto)_minmax(5.5rem,auto)_minmax(10rem,auto)_1fr] items-center gap-x-6 gap-y-2">
         <span className="text-ta-grey-300">metric</span>
-        <span className="text-right text-ta-grey-300">A</span>
-        <span className="text-center text-ta-grey-300">B vs A · scale ±{pct(scale)}</span>
-        <span className="text-ta-grey-300">B</span>
-        <span className="text-right text-ta-grey-300">delta</span>
+        <span className="truncate text-right text-ta-grey-300">{labels.a}</span>
+        <span className="truncate text-right text-ta-grey-300">{labels.b}</span>
+        <span className="text-right text-ta-grey-300">change</span>
+        <span className="text-ta-grey-300">size of change</span>
         {rows.map(({ m, rel }) => {
           const delta = metricDelta(m);
           return (
             <div key={m.key} className="contents">
               <span className="text-ta-grey-200">{m.key}</span>
               <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.a)}</span>
-              <DeltaBar rel={rel} scale={scale} />
-              <span className="text-ta-grey-100">{metricValue(m.kind, m.b)}</span>
+              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.b)}</span>
               <span
-                className={cn("text-right", delta === "=" ? "text-ta-grey-300" : "text-ta-sand-50")}
+                className={cn("text-right", rel === 0 ? "text-ta-grey-300" : "text-ta-sand-50")}
               >
+                {rel !== 0 && (
+                  <span aria-hidden className="text-ta-orange-300">
+                    {rel > 0 ? "▲ " : "▼ "}
+                  </span>
+                )}
                 {delta}
               </span>
+              <MagnitudeBar rel={rel} scale={scale} />
             </div>
           );
         })}
@@ -190,24 +223,16 @@ function relativeDelta(metric: ComparedMetric): number {
   return metric.b > 0 ? 1 : 0;
 }
 
-function pct(fraction: number): string {
-  const points = fraction * 100;
-  return `${points >= 10 ? Math.round(points) : Math.round(points * 10) / 10}%`;
-}
-
-function DeltaBar({ rel, scale }: { rel: number; scale: number }) {
-  const half = Math.min((Math.abs(rel) / scale) * 50, 50);
-  const width = rel === 0 ? 0 : Math.max(half, 0.75);
+/** Left-anchored |change| bar; direction lives in the row's arrow, not here. */
+function MagnitudeBar({ rel, scale }: { rel: number; scale: number }) {
+  const width = rel === 0 ? 0 : Math.max(Math.min((Math.abs(rel) / scale) * 100, 100), 1);
   return (
-    <div className="relative h-3 w-full bg-ta-grey-450/60">
-      <span aria-hidden className="absolute inset-y-0 left-1/2 w-px bg-ta-grey-300" />
+    <div className="relative h-3 w-full max-w-2xl bg-ta-grey-450/60">
       {width > 0 && (
         <span
           aria-hidden
-          className="absolute inset-y-[3px] bg-ta-orange-300"
-          style={
-            rel > 0 ? { left: "50%", width: `${width}%` } : { right: "50%", width: `${width}%` }
-          }
+          className="absolute inset-y-[3px] left-0 bg-ta-orange-300"
+          style={{ width: `${width}%` }}
         />
       )}
     </div>
@@ -216,7 +241,7 @@ function DeltaBar({ rel, scale }: { rel: number; scale: number }) {
 
 const ROW_GRID = "grid grid-cols-[4.5rem_1fr_1fr] gap-x-4";
 
-function Trajectory({ steps }: { steps: TrajectoryStep[] }) {
+function Trajectory({ steps, labels }: { steps: TrajectoryStep[]; labels: SideLabels }) {
   const [expanded, setExpanded] = useState<number>();
   const different = steps.filter(
     (step) => step.diverged || step.a === undefined || step.b === undefined,
@@ -237,8 +262,8 @@ function Trajectory({ steps }: { steps: TrajectoryStep[] }) {
           )}
         >
           <span>gen</span>
-          <span>A</span>
-          <span>B</span>
+          <span className="truncate">A · {labels.a}</span>
+          <span className="truncate">B · {labels.b}</span>
         </div>
         {steps.map((step, row) => {
           const differs = step.diverged || step.a === undefined || step.b === undefined;

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -2,21 +2,26 @@ import type { RunSummary } from "@core/collection";
 import {
   type ComparableTrace,
   type ComparedMetric,
+  collectToolDefs,
   compareTraces,
   metricDelta,
   metricValue,
+  type PromptDiff,
   pairTrajectory,
+  stepAction,
+  stepDiffers,
+  stepIndexLabel,
   type TraceComparison,
   type TrajectoryStep,
 } from "@core/compare";
-import { formatCallNames, formatSeconds, formatTokens } from "@core/format";
-import { toolCallNames } from "@core/normalize";
-import type { Generation, NormalizedTrace, RawTrace } from "@core/types";
+import { formatSeconds, formatTokens } from "@core/format";
+import type { Generation, NormalizedTrace, RawToolDef } from "@core/types";
 import { useEffect, useMemo, useState } from "react";
 import { MessageCard } from "@/components/MessageCard";
 import { Button } from "@/components/ui/button";
-import { localTraceItem } from "@/lib/use-trace";
-import { cn } from "@/lib/utils";
+import { fetchJson } from "@/lib/api";
+import { localTraceItem } from "@/lib/local-traces";
+import { basename, cn } from "@/lib/utils";
 
 interface CompareViewProps {
   runs: RunSummary[];
@@ -104,11 +109,10 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
 /** A short, human name for a side: file basename without the trace suffix. */
 function shortLabel(runs: RunSummary[], id: string): string {
   const run = runs.find((r) => r.id === id);
-  const base = run?.source
-    ?.split(/[\\/]/)
-    .filter(Boolean)
-    .at(-1)
-    ?.replace(/\.trace\.json$|\.json$/, "");
+  const base =
+    run?.source !== undefined
+      ? basename(run.source).replace(/\.trace\.json$|\.json$/, "")
+      : undefined;
   const label = base ?? run?.name ?? id;
   return label.length > 16 ? `${label.slice(0, 15)}…` : label;
 }
@@ -144,8 +148,7 @@ function RunSelect({
 
 /** "file.json · run name" so cross-file picks stay legible. */
 function runLabel(run: RunSummary): string {
-  const base = run.source?.split(/[\\/]/).filter(Boolean).at(-1);
-  return base !== undefined ? `${base} · ${run.name}` : run.name;
+  return run.source !== undefined ? `${basename(run.source)} · ${run.name}` : run.name;
 }
 
 interface SideLabels {
@@ -255,9 +258,7 @@ const ROW_GRID = "grid grid-cols-[4.5rem_1fr_1fr] gap-x-4";
 
 function Trajectory({ steps, labels }: { steps: TrajectoryStep[]; labels: SideLabels }) {
   const [expanded, setExpanded] = useState<number>();
-  const different = steps.filter(
-    (step) => step.diverged || step.a === undefined || step.b === undefined,
-  );
+  const different = steps.filter(stepDiffers);
   return (
     <Section
       label={
@@ -278,7 +279,7 @@ function Trajectory({ steps, labels }: { steps: TrajectoryStep[]; labels: SideLa
           <span className="truncate">B · {labels.b}</span>
         </div>
         {steps.map((step, row) => {
-          const differs = step.diverged || step.a === undefined || step.b === undefined;
+          const differs = stepDiffers(step);
           return (
             <div
               key={`${step.a?.index ?? "-"}:${step.b?.index ?? "-"}`}
@@ -321,20 +322,9 @@ function Trajectory({ steps, labels }: { steps: TrajectoryStep[]; labels: SideLa
   );
 }
 
-/** "12" when both sides sit at the same generation, else "a12/b13" style. */
-function stepIndexLabel(step: TrajectoryStep): string {
-  if (step.a !== undefined && step.b !== undefined) {
-    return step.a.index === step.b.index
-      ? String(step.a.index)
-      : `a${step.a.index}/b${step.b.index}`;
-  }
-  return step.a !== undefined ? `a${step.a.index}` : `b${step.b!.index}`;
-}
-
 function GenCell({ gen, diverged }: { gen?: Generation; diverged: boolean }) {
   if (gen === undefined) return <span className="text-ta-grey-300">-</span>;
-  const calls = formatCallNames(toolCallNames(gen));
-  const doing = calls !== "" ? calls : `-> ${(gen.newMessages.at(-1)?.text ?? "").slice(0, 80)}`;
+  const doing = stepAction(gen, 80);
   return (
     <span className="flex min-w-0 items-baseline gap-3">
       <span className={cn("min-w-0 truncate", diverged ? "text-ta-orange-75" : "text-ta-grey-100")}>
@@ -367,17 +357,17 @@ function GenDetail({ gen }: { gen?: Generation }) {
 /** Full diff is rendered; the pane scrolls. */
 const MAX_RENDERED_DIFF_LINES = 600;
 
-function PromptSection({ prompt }: { prompt: TraceComparison["systemPrompt"] }) {
-  if (prompt.same) {
+function PromptSection({ prompt }: { prompt: PromptDiff }) {
+  if (prompt.kind === "identical") {
     return (
       <Section label="system prompt">
         <p className="type-body-s text-ta-grey-200">
-          {prompt.aChars === 0 ? "none in either run" : `identical (${prompt.aChars} chars)`}
+          {prompt.chars === 0 ? "none in either run" : `identical (${prompt.chars} chars)`}
         </p>
       </Section>
     );
   }
-  if (prompt.lines === undefined) {
+  if (prompt.kind === "too-large") {
     return (
       <Section label="system prompt">
         <p className="type-body-s text-ta-grey-200">
@@ -448,21 +438,15 @@ function Section({ label, children }: { label: string; children: React.ReactNode
   );
 }
 
-/** A run's trace + raw, from local memory for browser-opened files, else the server. */
+/** A run's comparable form, from local memory for browser-opened files, else the server. */
 async function loadSide(id: string): Promise<ComparableTrace> {
   const local = localTraceItem(id);
-  if (local !== undefined) return local;
-  const [trace, raw] = await Promise.all([
+  if (local !== undefined) return { trace: local.trace, tools: collectToolDefs(local.raw) };
+  const [trace, tools] = await Promise.all([
     fetchJson(`/api/trace?id=${encodeURIComponent(id)}`) as Promise<NormalizedTrace>,
-    (fetchJson(`/api/raw?id=${encodeURIComponent(id)}&path=`) as Promise<{ value: RawTrace }>).then(
-      (body) => body.value,
+    (fetchJson(`/api/tools?id=${encodeURIComponent(id)}`) as Promise<{ tools: RawToolDef[] }>).then(
+      (body) => body.tools,
     ),
   ]);
-  return { trace, raw };
-}
-
-async function fetchJson(url: string): Promise<unknown> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
-  return res.json();
+  return { trace, tools };
 }

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -1,6 +1,7 @@
 import type { RunSummary } from "@core/collection";
 import {
   type ComparableTrace,
+  type ComparedMetric,
   compareTraces,
   metricDelta,
   metricValue,
@@ -135,33 +136,72 @@ function MetricsGrid({ comparison }: { comparison: TraceComparison }) {
           : `totals · A: ${models.a.join(", ")} · B: ${models.b.join(", ")}`
       }
     >
-      <div className="type-accent-s grid max-w-2xl grid-cols-[1fr_auto_auto_auto] gap-x-8 gap-y-1.5">
-        <HeaderCell>metric</HeaderCell>
-        <HeaderCell right>A</HeaderCell>
-        <HeaderCell right>B</HeaderCell>
-        <HeaderCell right>delta</HeaderCell>
-        {metrics.map((m) => {
-          const delta = metricDelta(m);
-          return (
-            <div key={m.key} className="contents">
-              <span className="text-ta-grey-200">{m.key}</span>
-              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.a)}</span>
-              <span className="text-right text-ta-grey-100">{metricValue(m.kind, m.b)}</span>
-              <span
-                className={cn("text-right", delta === "=" ? "text-ta-grey-300" : "text-ta-sand-50")}
-              >
-                {delta}
-              </span>
-            </div>
-          );
-        })}
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
+        {metrics.map((m) => (
+          <MetricTile key={m.key} metric={m} />
+        ))}
       </div>
     </Section>
   );
 }
 
-function HeaderCell({ children, right }: { children: React.ReactNode; right?: boolean }) {
-  return <span className={cn("text-ta-grey-300", right && "text-right")}>{children}</span>;
+/** One headline metric as a stat tile: name, prominent delta, A/B bars and values. */
+function MetricTile({ metric }: { metric: ComparedMetric }) {
+  const delta = metricDelta(metric);
+  return (
+    <div className="flex flex-col gap-2.5 border border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="type-accent-s text-ta-grey-200">{metric.key}</span>
+        <span
+          className={cn("type-accent-m", delta === "=" ? "text-ta-grey-300" : "text-ta-sand-50")}
+        >
+          {delta}
+        </span>
+      </div>
+      <MetricBars metric={metric} />
+      <div className="type-accent-s flex justify-between gap-3 text-ta-grey-100">
+        <span>
+          <SeriesChip className="bg-ta-grey-300" /> A {metricValue(metric.kind, metric.a)}
+        </span>
+        <span>
+          <SeriesChip className="bg-ta-orange-300" /> B {metricValue(metric.kind, metric.b)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** Ties a bar's series color to its value column. */
+function SeriesChip({ className }: { className: string }) {
+  return <span aria-hidden className={cn("mr-1 inline-block size-1.5 align-middle", className)} />;
+}
+
+/**
+ * Paired A/B bars per metric. Each row scales to its own max - tokens,
+ * dollars, and seconds share no axis - except shares, which scale to 100%
+ * so the bar length is the honest ratio. A is the neutral reference, B the
+ * accent; identity is also carried by position and the labeled columns.
+ */
+function MetricBars({ metric }: { metric: ComparedMetric }) {
+  const scale = metric.kind === "share" ? 1 : Math.max(metric.a, metric.b);
+  const width = (v: number) => (scale <= 0 || v <= 0 ? "0%" : `${Math.max((v / scale) * 100, 2)}%`);
+  return (
+    <div
+      className="flex min-w-16 flex-col gap-0.5"
+      title={`A ${metricValue(metric.kind, metric.a)} · B ${metricValue(metric.kind, metric.b)}`}
+    >
+      <Bar className="bg-ta-grey-300" width={width(metric.a)} />
+      <Bar className="bg-ta-orange-300" width={width(metric.b)} />
+    </div>
+  );
+}
+
+function Bar({ className, width }: { className: string; width: string }) {
+  return (
+    <div className="h-[5px] w-full bg-ta-grey-450">
+      <div className={cn("h-full", className)} style={{ width }} />
+    </div>
+  );
 }
 
 const ROW_GRID = "grid grid-cols-[4.5rem_1fr_1fr] gap-x-4";

--- a/src/viewer/components/DefinitionDialog.tsx
+++ b/src/viewer/components/DefinitionDialog.tsx
@@ -7,8 +7,8 @@ import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Markdown } from "@/components/ui/markdown";
+import { localRawTrace } from "@/lib/local-traces";
 import type { TreemapLeaf } from "@/lib/treemap-data";
-import { localRawTrace } from "@/lib/use-trace";
 
 /** Full definition of a clicked treemap block: pretty-rendered, raw JSON a toggle away. */
 export function DefinitionDialog({

--- a/src/viewer/components/Header.tsx
+++ b/src/viewer/components/Header.tsx
@@ -49,11 +49,7 @@ export function Header({ trace, agentCommand, onCompare, comparing, onClear }: H
         {agentCommand ? (
           <CopyButton label="copy for agent" text={agentCommand} title={agentCommand} />
         ) : (
-          <Button
-            disabled
-            className="cursor-default opacity-40 hover:border-ta-grey-400 hover:text-ta-grey-100"
-            title="opened in this browser - agents need a file on disk"
-          >
+          <Button disabled title="opened in this browser - agents need a file on disk">
             copy for agent
           </Button>
         )}

--- a/src/viewer/components/Header.tsx
+++ b/src/viewer/components/Header.tsx
@@ -8,13 +8,14 @@ interface HeaderProps {
   trace: NormalizedTrace;
   /** Shell command an agent runs to explore this run from the CLI. */
   agentCommand?: string;
-  /** Present when at least two runs exist; opens the A/B compare dialog. */
+  /** Present when at least two runs exist; toggles the A/B compare view. */
   onCompare?: () => void;
+  comparing?: boolean;
   /** Present in live devtools mode; empties the backing database. */
   onClear?: () => void;
 }
 
-export function Header({ trace, agentCommand, onCompare, onClear }: HeaderProps) {
+export function Header({ trace, agentCommand, onCompare, comparing, onClear }: HeaderProps) {
   return (
     <header className="flex items-baseline gap-6 overflow-hidden border-b border-ta-grey-400 px-6 py-4">
       <h1 className="type-accent-m shrink-0 text-ta-orange-300">unbox-ai</h1>
@@ -36,7 +37,15 @@ export function Header({ trace, agentCommand, onCompare, onClear }: HeaderProps)
         />
         {/* traces without price data report 0 - a real run never costs exactly $0 */}
         {trace.totalCost > 0 && <Stat label="cost" value={formatCost(trace.totalCost)} />}
-        {onCompare && <Button onClick={onCompare}>compare</Button>}
+        {onCompare && (
+          <Button
+            onClick={onCompare}
+            aria-pressed={comparing}
+            className={comparing ? "border-ta-orange-300 text-ta-orange-300" : undefined}
+          >
+            compare
+          </Button>
+        )}
         {agentCommand ? (
           <CopyButton label="copy for agent" text={agentCommand} title={agentCommand} />
         ) : (

--- a/src/viewer/components/Header.tsx
+++ b/src/viewer/components/Header.tsx
@@ -8,11 +8,13 @@ interface HeaderProps {
   trace: NormalizedTrace;
   /** Shell command an agent runs to explore this run from the CLI. */
   agentCommand?: string;
+  /** Present when at least two runs exist; opens the A/B compare dialog. */
+  onCompare?: () => void;
   /** Present in live devtools mode; empties the backing database. */
   onClear?: () => void;
 }
 
-export function Header({ trace, agentCommand, onClear }: HeaderProps) {
+export function Header({ trace, agentCommand, onCompare, onClear }: HeaderProps) {
   return (
     <header className="flex items-baseline gap-6 overflow-hidden border-b border-ta-grey-400 px-6 py-4">
       <h1 className="type-accent-m shrink-0 text-ta-orange-300">unbox-ai</h1>
@@ -34,6 +36,7 @@ export function Header({ trace, agentCommand, onClear }: HeaderProps) {
         />
         {/* traces without price data report 0 - a real run never costs exactly $0 */}
         {trace.totalCost > 0 && <Stat label="cost" value={formatCost(trace.totalCost)} />}
+        {onCompare && <Button onClick={onCompare}>compare</Button>}
         {agentCommand ? (
           <CopyButton label="copy for agent" text={agentCommand} title={agentCommand} />
         ) : (

--- a/src/viewer/components/SourceTabs.tsx
+++ b/src/viewer/components/SourceTabs.tsx
@@ -1,7 +1,7 @@
 import type { RunSummary } from "@core/collection";
 import { useRef } from "react";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { basename, cn, pathSegments } from "@/lib/utils";
 
 export interface SourceTab {
   /** Absolute path (server files) or file name (browser-opened); the grouping key. */
@@ -33,14 +33,16 @@ export function sourceTabs(runs: RunSummary[]): SourceTab[] {
 
 /** Basenames, widened to parent/basename when two files share a name. */
 function disambiguate(sources: string[]): Map<string, string> {
-  const segments = (path: string) => path.split(/[\\/]/).filter(Boolean);
-  const base = (path: string) => segments(path).at(-1) ?? path;
   const counts = new Map<string, number>();
-  for (const source of sources) counts.set(base(source), (counts.get(base(source)) ?? 0) + 1);
+  for (const source of sources) {
+    counts.set(basename(source), (counts.get(basename(source)) ?? 0) + 1);
+  }
   return new Map(
     sources.map((source) => [
       source,
-      counts.get(base(source))! > 1 ? segments(source).slice(-2).join("/") : base(source),
+      counts.get(basename(source))! > 1
+        ? pathSegments(source).slice(-2).join("/")
+        : basename(source),
     ]),
   );
 }

--- a/src/viewer/components/ui/button.tsx
+++ b/src/viewer/components/ui/button.tsx
@@ -12,6 +12,7 @@ function Button({ className, ...props }: ComponentProps<"button">) {
       className={cn(
         "type-accent-s inline-flex h-7 cursor-pointer items-center border border-ta-grey-400 px-3 text-ta-grey-100",
         "transition-colors hover:border-ta-sand-300 hover:text-ta-sand-50",
+        "disabled:cursor-default disabled:opacity-40 disabled:hover:border-ta-grey-400 disabled:hover:text-ta-grey-100",
         className,
       )}
       {...props}

--- a/src/viewer/lib/api.ts
+++ b/src/viewer/lib/api.ts
@@ -1,0 +1,6 @@
+/** Fetches a JSON api route, throwing the server's error message on failure. */
+export async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
+  return res.json();
+}

--- a/src/viewer/lib/local-traces.ts
+++ b/src/viewer/lib/local-traces.ts
@@ -1,0 +1,71 @@
+import type { TraceCollectionItem } from "@core/collection";
+import type { RawTrace } from "@core/types";
+
+/** Browser-opened runs by trace id; parsed locally, never known to the server. */
+const items = new Map<string, TraceCollectionItem>();
+
+/** Every browser-opened run, in open order. */
+export function localItems(): TraceCollectionItem[] {
+  return [...items.values()];
+}
+
+/** The raw trace behind a browser-opened run, or undefined for server runs. */
+export function localRawTrace(traceId: string): RawTrace | undefined {
+  return items.get(traceId)?.raw;
+}
+
+/** A browser-opened run with its raw form, or undefined for server runs. */
+export function localTraceItem(traceId: string): TraceCollectionItem | undefined {
+  return items.get(traceId);
+}
+
+/** Registers adopted runs; they last until the page reloads or their source closes. */
+export function addLocalItems(adopted: TraceCollectionItem[]): void {
+  for (const item of adopted) items.set(item.trace.traceId, item);
+}
+
+/** Drops every browser-opened run of a closed source. */
+export function removeLocalSource(source: string): void {
+  for (const [id, item] of items) {
+    if (item.sourcePath === source) items.delete(id);
+  }
+}
+
+/** The dropped file's name, counted up when a tab by that name already exists. */
+export function uniqueSource(name: string, taken: Set<string>): string {
+  if (!taken.has(name)) return name;
+  for (let n = 2; ; n++) if (!taken.has(`${name} (${n})`)) return `${name} (${n})`;
+}
+
+/**
+ * Tags parsed runs with their tab source and de-collides run ids against
+ * already-listed ones (reopening a served file), keeping parent links whole.
+ */
+export function adoptItems(
+  parsed: TraceCollectionItem[],
+  source: string,
+  takenIds: Set<string>,
+): TraceCollectionItem[] {
+  const rename = new Map<string, string>();
+  for (const { trace } of parsed) {
+    let id = trace.traceId;
+    if (takenIds.has(id)) {
+      let n = 2;
+      while (takenIds.has(`${id} (${n})`)) n++;
+      id = `${id} (${n})`;
+      rename.set(trace.traceId, id);
+    }
+    takenIds.add(id);
+  }
+  return parsed.map((item) => {
+    const trace = {
+      ...item.trace,
+      traceId: rename.get(item.trace.traceId) ?? item.trace.traceId,
+      parentTraceId:
+        item.trace.parentTraceId !== undefined
+          ? (rename.get(item.trace.parentTraceId) ?? item.trace.parentTraceId)
+          : undefined,
+    };
+    return { raw: item.raw, trace, sourcePath: source };
+  });
+}

--- a/src/viewer/lib/use-trace.ts
+++ b/src/viewer/lib/use-trace.ts
@@ -21,12 +21,17 @@ interface TraceState {
   live: boolean;
 }
 
-/** Raw traces of browser-opened files; stands in for /api/raw on their runs. */
-const localRaws = new Map<string, RawTrace>();
+/** Browser-opened runs by trace id; parsed locally, never known to the server. */
+const localItems = new Map<string, TraceCollectionItem>();
 
 /** The raw trace behind a browser-opened run, or undefined for server runs. */
 export function localRawTrace(traceId: string): RawTrace | undefined {
-  return localRaws.get(traceId);
+  return localItems.get(traceId)?.raw;
+}
+
+/** A browser-opened run with its raw form, or undefined for server runs. */
+export function localTraceItem(traceId: string): TraceCollectionItem | undefined {
+  return localItems.get(traceId);
 }
 
 /**
@@ -49,7 +54,6 @@ export function useTrace(): TraceState & {
   const pinnedRef = useRef(false);
   const seqRef = useRef(0);
   const loadRef = useRef(() => {});
-  const localItemsRef = useRef<TraceCollectionItem[]>([]);
   const closedRef = useRef(new Set<string>());
   const runsRef = useRef<RunSummary[]>([]);
 
@@ -57,7 +61,7 @@ export function useTrace(): TraceState & {
     const seq = ++seqRef.current;
     try {
       const serverRuns = (await fetchJson("/api/traces")) as RunSummary[];
-      const runs = [...serverRuns, ...runSummaries(localItemsRef.current)].filter(
+      const runs = [...serverRuns, ...runSummaries([...localItems.values()])].filter(
         (run) => run.source === undefined || !closedRef.current.has(run.source),
       );
       const latest = defaultRun(runs);
@@ -71,7 +75,7 @@ export function useTrace(): TraceState & {
         pinnedRef.current = false;
       }
       selectedRef.current = selected;
-      const local = localItemsRef.current.find((item) => item.trace.traceId === selected);
+      const local = selected !== undefined ? localItems.get(selected) : undefined;
       const [trace, command] =
         selected === undefined
           ? [undefined, undefined]
@@ -136,7 +140,7 @@ export function useTrace(): TraceState & {
           const items = parseCollection(JSON.parse(await file.text())).items;
           if (items.length === 0) throw new Error("no runs");
           const adopted = adoptItems(items, uniqueSource(file.name, takenSources()), takenIds());
-          localItemsRef.current = [...localItemsRef.current, ...adopted];
+          for (const item of adopted) localItems.set(item.trace.traceId, item);
           lastOpened = adopted.at(-1);
         } catch {
           failure = `${file.name}: not a readable trace`;
@@ -153,12 +157,12 @@ export function useTrace(): TraceState & {
     function takenSources(): Set<string> {
       const taken = new Set(closedRef.current);
       for (const run of runsRef.current) if (run.source !== undefined) taken.add(run.source);
-      for (const item of localItemsRef.current) taken.add(item.sourcePath!);
+      for (const item of localItems.values()) taken.add(item.sourcePath!);
       return taken;
     }
     function takenIds(): Set<string> {
       const taken = new Set(runsRef.current.map((run) => run.id));
-      for (const item of localItemsRef.current) taken.add(item.trace.traceId);
+      for (const id of localItems.keys()) taken.add(id);
       return taken;
     }
   }, []);
@@ -169,10 +173,9 @@ export function useTrace(): TraceState & {
       (s): s is string => s !== undefined,
     );
     closedRef.current.add(source);
-    for (const item of localItemsRef.current) {
-      if (item.sourcePath === source) localRaws.delete(item.trace.traceId);
+    for (const [id, item] of localItems) {
+      if (item.sourcePath === source) localItems.delete(id);
     }
-    localItemsRef.current = localItemsRef.current.filter((item) => item.sourcePath !== source);
     // closing the active tab activates its right neighbor, else the left one
     if (runs.find((run) => run.id === selectedRef.current)?.source === source) {
       const index = order.indexOf(source);
@@ -234,7 +237,6 @@ function adoptItems(
           ? (rename.get(item.trace.parentTraceId) ?? item.trace.parentTraceId)
           : undefined,
     };
-    localRaws.set(trace.traceId, item.raw);
     return { raw: item.raw, trace, sourcePath: source };
   });
 }

--- a/src/viewer/lib/use-trace.ts
+++ b/src/viewer/lib/use-trace.ts
@@ -4,8 +4,17 @@ import {
   runSummaries,
   type TraceCollectionItem,
 } from "@core/collection";
-import type { NormalizedTrace, RawTrace } from "@core/types";
+import type { NormalizedTrace } from "@core/types";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchJson } from "@/lib/api";
+import {
+  addLocalItems,
+  adoptItems,
+  localItems,
+  localTraceItem,
+  removeLocalSource,
+  uniqueSource,
+} from "@/lib/local-traces";
 
 interface TraceState {
   /** One entry per independent run, chronological; absent until loaded. */
@@ -19,19 +28,6 @@ interface TraceState {
   openError?: string;
   /** True when the server pushes updates (unbox-ai devtools mode). */
   live: boolean;
-}
-
-/** Browser-opened runs by trace id; parsed locally, never known to the server. */
-const localItems = new Map<string, TraceCollectionItem>();
-
-/** The raw trace behind a browser-opened run, or undefined for server runs. */
-export function localRawTrace(traceId: string): RawTrace | undefined {
-  return localItems.get(traceId)?.raw;
-}
-
-/** A browser-opened run with its raw form, or undefined for server runs. */
-export function localTraceItem(traceId: string): TraceCollectionItem | undefined {
-  return localItems.get(traceId);
 }
 
 /**
@@ -61,7 +57,7 @@ export function useTrace(): TraceState & {
     const seq = ++seqRef.current;
     try {
       const serverRuns = (await fetchJson("/api/traces")) as RunSummary[];
-      const runs = [...serverRuns, ...runSummaries([...localItems.values()])].filter(
+      const runs = [...serverRuns, ...runSummaries(localItems())].filter(
         (run) => run.source === undefined || !closedRef.current.has(run.source),
       );
       const latest = defaultRun(runs);
@@ -75,7 +71,7 @@ export function useTrace(): TraceState & {
         pinnedRef.current = false;
       }
       selectedRef.current = selected;
-      const local = selected !== undefined ? localItems.get(selected) : undefined;
+      const local = selected !== undefined ? localTraceItem(selected) : undefined;
       const [trace, command] =
         selected === undefined
           ? [undefined, undefined]
@@ -140,7 +136,7 @@ export function useTrace(): TraceState & {
           const items = parseCollection(JSON.parse(await file.text())).items;
           if (items.length === 0) throw new Error("no runs");
           const adopted = adoptItems(items, uniqueSource(file.name, takenSources()), takenIds());
-          for (const item of adopted) localItems.set(item.trace.traceId, item);
+          addLocalItems(adopted);
           lastOpened = adopted.at(-1);
         } catch {
           failure = `${file.name}: not a readable trace`;
@@ -157,12 +153,12 @@ export function useTrace(): TraceState & {
     function takenSources(): Set<string> {
       const taken = new Set(closedRef.current);
       for (const run of runsRef.current) if (run.source !== undefined) taken.add(run.source);
-      for (const item of localItems.values()) taken.add(item.sourcePath!);
+      for (const item of localItems()) taken.add(item.sourcePath!);
       return taken;
     }
     function takenIds(): Set<string> {
       const taken = new Set(runsRef.current.map((run) => run.id));
-      for (const id of localItems.keys()) taken.add(id);
+      for (const item of localItems()) taken.add(item.trace.traceId);
       return taken;
     }
   }, []);
@@ -173,9 +169,7 @@ export function useTrace(): TraceState & {
       (s): s is string => s !== undefined,
     );
     closedRef.current.add(source);
-    for (const [id, item] of localItems) {
-      if (item.sourcePath === source) localItems.delete(id);
-    }
+    removeLocalSource(source);
     // closing the active tab activates its right neighbor, else the left one
     if (runs.find((run) => run.id === selectedRef.current)?.source === source) {
       const index = order.indexOf(source);
@@ -202,45 +196,6 @@ function defaultRun(runs: RunSummary[]): string | undefined {
   return sameSource.length === runs.length ? runs.at(-1)?.id : sameSource.at(-1)?.id;
 }
 
-/** The dropped file's name, counted up when a tab by that name already exists. */
-function uniqueSource(name: string, taken: Set<string>): string {
-  if (!taken.has(name)) return name;
-  for (let n = 2; ; n++) if (!taken.has(`${name} (${n})`)) return `${name} (${n})`;
-}
-
-/**
- * Tags parsed runs with their tab source and de-collides run ids against
- * already-listed ones (reopening a served file), keeping parent links whole.
- */
-function adoptItems(
-  items: TraceCollectionItem[],
-  source: string,
-  takenIds: Set<string>,
-): TraceCollectionItem[] {
-  const rename = new Map<string, string>();
-  for (const { trace } of items) {
-    let id = trace.traceId;
-    if (takenIds.has(id)) {
-      let n = 2;
-      while (takenIds.has(`${id} (${n})`)) n++;
-      id = `${id} (${n})`;
-      rename.set(trace.traceId, id);
-    }
-    takenIds.add(id);
-  }
-  return items.map((item) => {
-    const trace = {
-      ...item.trace,
-      traceId: rename.get(item.trace.traceId) ?? item.trace.traceId,
-      parentTraceId:
-        item.trace.parentTraceId !== undefined
-          ? (rename.get(item.trace.parentTraceId) ?? item.trace.parentTraceId)
-          : undefined,
-    };
-    return { raw: item.raw, trace, sourcePath: source };
-  });
-}
-
 /** Sources without a file path (or older servers) have no command; not an error. */
 async function fetchCommand(id: string): Promise<string | undefined> {
   try {
@@ -250,10 +205,4 @@ async function fetchCommand(id: string): Promise<string | undefined> {
   } catch {
     return undefined;
   }
-}
-
-async function fetchJson(url: string): Promise<unknown> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? `HTTP ${res.status}`);
-  return res.json();
 }

--- a/src/viewer/lib/utils.ts
+++ b/src/viewer/lib/utils.ts
@@ -5,3 +5,13 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+/** Path components, either separator style, empty segments dropped. */
+export function pathSegments(path: string): string[] {
+  return path.split(/[\\/]/).filter(Boolean);
+}
+
+/** Last path component, or the path itself when it has none. */
+export function basename(path: string): string {
+  return pathSegments(path).at(-1) ?? path;
+}


### PR DESCRIPTION
# Overview

Stacked on #3 (file tabs, browser trace opening, agent copy command) - merge that first.

A/B comparison of agent runs, end to end:

- `unbox-ai compare <a> <b>` (or one file with `--run <x> --run <y>`): metric deltas, system prompt line diff, tool-set diff, and a content-aligned trajectory (`--trajectory`, LCS over action sequences so an inserted step doesn't cascade divergence). `--json` carries the full diff.
- Viewer compare view: hero-delta metric tiles with paired A/B bars, expandable aligned trajectory, prompt + tools diff, run pickers with swap.
- Time-split rows (prompt wait / output / unattributed / tool time) - unattributed is where hidden reasoning time shows up.

Last commit is a post-review refactor: shared trajectory helpers in core (CLI and viewer render from the same functions), declarative `METRIC_ROWS` instead of hand-paired a/b rows, `PromptDiff` as a discriminated union, `ComparableTrace` carries tool defs with a small `/api/tools` endpoint instead of hauling full raw traces, local-file store extracted out of the `useTrace` hook.

## Test plan

- [x] `npm run check` passes (lint + typecheck + tests; 49 tests incl. new compare, diff, /api/tools, /api/command coverage)
- [x] Verified against real traces: `compare qa-agent.trace.json opencode.trace.json` (plain, `--trajectory`, `--json`), `compare ai-sdk.trace.json --run 0 --run 1`, and the built server's `/api/tools` returning 42 deduped defs for the qa-agent run