### PR TITLE
feat(compare): deeper trace diffing - per-tool detail, task diff, usage deltas, outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ unbox-ai compare a.json b.json       # A/B two runs: metric deltas + system prom
 ```
 
 `compare` is built for prompt and model A/B: it prints token / cost / time /
-cache deltas, then a line diff of the system prompt and the added / removed /
-changed tool definitions - "what changed and what did it buy". Add
+cache deltas, then a line diff of the system prompt and the tool-set changes -
+added / removed names plus, per changed tool, what changed (description or
+schema) and the definition diff ("what changed and what did it buy"). Add
 `--trajectory` for a content-aligned action table (LCS over tool sequences,
 so an extra step in one run offsets nothing) that marks exactly which steps
 differ. Two runs of one file: `unbox-ai compare db.json --run 0

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ unbox-ai compare a.json b.json       # A/B two runs: metric deltas + system prom
 ```
 
 `compare` is built for prompt and model A/B: it prints token / cost / time /
-cache deltas, then a line diff of the system prompt and the tool-set changes -
-added / removed names plus, per changed tool, what changed (description or
-schema) and the definition diff ("what changed and what did it buy"). Add
+cache deltas, a diff of the task (differing tasks make every delta
+misleading), per-tool usage deltas (which tools each run leaned on), then a
+line diff of the system prompt and the tool-set changes - added / removed
+names plus, per changed tool, what changed (description or schema) and the
+definition diff ("what changed and what did it buy"). Add
 `--trajectory` for a content-aligned action table (LCS over tool sequences,
 so an extra step in one run offsets nothing) that marks exactly which steps
 differ. Two runs of one file: `unbox-ai compare db.json --run 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "unbox-ai",
       "version": "0.3.0",
       "license": "MIT",
+      "dependencies": {
+        "@pierre/diffs": "1.3.6"
+      },
       "bin": {
         "unbox-ai": "dist/cli/index.js"
       },
@@ -1443,6 +1446,64 @@
         "url": "https://github.com/phun-ky/typeof?sponsor=1"
       }
     },
+    "node_modules/@pierre/diffs": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.3.6.tgz",
+      "integrity": "sha512-a3woaW2QHy78JDxPJK0OJzwZUN4xoQLLIS/pceO8X6+L8gA5D682mP7/w3YxxEVRPXOaoe/p/RJ5Oj/3nrEzew==",
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "2.0.0",
+        "@pierre/theming": "1.0.1",
+        "@shikijs/transformers": "^3.0.0 || ^4.0.0",
+        "diff": "9.0.0",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-2.0.0.tgz",
+      "integrity": "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==",
+      "license": "apache-2.0",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
+    "node_modules/@pierre/theming": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-1.0.1.tgz",
+      "integrity": "sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==",
+      "license": "apache-2.0",
+      "peerDependencies": {
+        "@pierre/theme": "^1.1.0 || ^2.0.0",
+        "@shikijs/themes": "^3.0.0 || ^4.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pierre/theme": {
+          "optional": true
+        },
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "shiki": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@release-it/conventional-changelog": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-12.0.0.tgz",
@@ -2134,6 +2195,119 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.4.3.tgz",
+      "integrity": "sha512-oJSARV6NaWd+rnNJbtnpAdj3Zg0ZVyzsnMgb3vi3HA+35y8lBWUCpOnWsmyiXZIikY+x1BDqrQUgmxfzWh7Jvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
@@ -2606,7 +2780,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
       "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2616,7 +2789,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2670,14 +2842,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3071,7 +3241,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3116,7 +3285,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3127,7 +3295,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3237,7 +3404,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3566,7 +3732,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3593,7 +3758,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -3601,6 +3765,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {
@@ -3965,6 +4138,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3997,7 +4193,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -4016,6 +4211,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4667,6 +4872,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -4942,7 +5153,6 @@
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -5311,7 +5521,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5438,7 +5647,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5512,7 +5720,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5557,7 +5764,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5574,7 +5780,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5759,6 +5964,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/open": {
@@ -6055,7 +6277,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
       "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6139,7 +6360,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6149,7 +6369,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -6214,6 +6433,30 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/release-it": {
       "version": "21.0.2",
@@ -6501,7 +6744,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -6515,6 +6757,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/siginfo": {
@@ -6602,7 +6863,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6667,7 +6927,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -6854,7 +7113,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7031,7 +7289,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -7045,7 +7302,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -7059,7 +7315,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -7073,7 +7328,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7089,7 +7343,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7138,7 +7391,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7153,7 +7405,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7712,7 +7963,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "typescript": "5.9.3",
     "vite": "8.2.2",
     "vitest": "^4.1.11"
+  },
+  "dependencies": {
+    "@pierre/diffs": "1.3.6"
   }
 }

--- a/skills/unbox-ai/SKILL.md
+++ b/skills/unbox-ai/SKILL.md
@@ -37,9 +37,10 @@ unbox-ai compare <a> <b>        # A/B: metric deltas + system prompt / tool-set 
 - `--grep` accepts regex; invalid regex silently falls back to literal search.
 - `tools --all` lists every individual call with args.
 - `compare` answers "what changed between these two runs": token/cost/time
-  deltas, then a line diff of the system prompt and the tool-set changes -
-  added/removed names plus, per changed tool, what changed (description or
-  schema). Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
+  deltas, a task diff (differing tasks make deltas misleading), per-tool
+  usage deltas, then a line diff of the system prompt and the tool-set
+  changes - added/removed names plus, per changed tool, what changed
+  (description or schema). Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
   scopes A, second B). Diff output is bounded; `--json` has the full diff.
   `--trajectory` adds a content-aligned action table (* = differing step,
   - = no counterpart; alignment is LCS over tool sequences, so an extra step

--- a/skills/unbox-ai/SKILL.md
+++ b/skills/unbox-ai/SKILL.md
@@ -37,8 +37,9 @@ unbox-ai compare <a> <b>        # A/B: metric deltas + system prompt / tool-set 
 - `--grep` accepts regex; invalid regex silently falls back to literal search.
 - `tools --all` lists every individual call with args.
 - `compare` answers "what changed between these two runs": token/cost/time
-  deltas, then a line diff of the system prompt and added/removed/changed
-  tools. Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
+  deltas, then a line diff of the system prompt and the tool-set changes -
+  added/removed names plus, per changed tool, what changed (description or
+  schema). Two runs of one file: `compare <trace> --run 0 --run 1` (first --run
   scopes A, second B). Diff output is bounded; `--json` has the full diff.
   `--trajectory` adds a content-aligned action table (* = differing step,
   - = no counterpart; alignment is LCS over tool sequences, so an extra step

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -10,6 +10,7 @@ import {
   stepIndexLabel,
   type ToolChange,
   type ToolsDiff,
+  type ToolUsageDelta,
   type TrajectoryStep,
 } from "../../core/compare";
 import type { DiffLine } from "../../core/diff";
@@ -59,6 +60,7 @@ export function compare(
       ? `models  ${models.a.join(", ")}`
       : `models  A: ${models.a.join(", ")}  B: ${models.b.join(", ")}`,
   );
+  printPromptDiff("task", comparison.task);
   console.log("");
   console.log(
     table(
@@ -72,8 +74,9 @@ export function compare(
     ),
   );
   console.log("");
-  printPromptDiff(comparison.systemPrompt);
+  printPromptDiff("system prompt", comparison.systemPrompt);
   printToolsDiff(comparison.tools);
+  printToolUsage(comparison.toolUsage);
   if (options.trajectory) {
     console.log("");
     printTrajectory(steps);
@@ -130,22 +133,21 @@ function side(loaded: LoadedTrace, label: string) {
   };
 }
 
-function printPromptDiff(diff: PromptDiff): void {
+function printPromptDiff(label: string, diff: PromptDiff): void {
+  const tag = label.padEnd(15);
   if (diff.kind === "identical") {
     console.log(
-      diff.chars === 0
-        ? "system prompt  none in either trace"
-        : `system prompt  identical (${diff.chars} chars)`,
+      diff.chars === 0 ? `${tag}none in either trace` : `${tag}identical (${diff.chars} chars)`,
     );
     return;
   }
   if (diff.kind === "too-large") {
     console.log(
-      `system prompt  differs (A ${diff.aChars} chars, B ${diff.bChars} chars - too large to line-diff, see --json)`,
+      `${tag}differs (A ${diff.aChars} chars, B ${diff.bChars} chars - too large to line-diff, see --json)`,
     );
     return;
   }
-  console.log(`system prompt  differs: +${diff.addedLines} / -${diff.removedLines} lines`);
+  console.log(`${tag}differs: +${diff.addedLines} / -${diff.removedLines} lines`);
   const printable = hunks(diff.lines);
   for (const line of printable.slice(0, MAX_DIFF_LINES)) console.log(`  ${line}`);
   if (printable.length > MAX_DIFF_LINES) {
@@ -197,6 +199,34 @@ function printToolsDiff(tools: ToolsDiff): void {
   }
   if (tools.changed.length > MAX_CHANGED_TOOLS) {
     console.log(`  [... ${tools.changed.length - MAX_CHANGED_TOOLS} more]`);
+  }
+}
+
+/** Per-tool call activity where the runs differ; identical rows just count. */
+function printToolUsage(usage: ToolUsageDelta[]): void {
+  const changed = usage.filter((u) => u.a.calls !== u.b.calls || u.a.failures !== u.b.failures);
+  if (changed.length === 0) return;
+  const same = usage.length - changed.length;
+  console.log(`\ntool usage (biggest change first${same > 0 ? ` · ${same} tools unchanged` : ""})`);
+  const pair = (a: number, b: number, render: (v: number) => string) =>
+    a === 0 && b === 0 ? "" : `${render(a)} -> ${render(b)}`;
+  console.log(
+    table(
+      ["tool", "A", "B", "delta", "failures", "time"],
+      changed
+        .slice(0, MAX_CHANGED_TOOLS)
+        .map((u) => [
+          u.name,
+          String(u.a.calls),
+          String(u.b.calls),
+          metricDelta({ key: u.name, kind: "count", a: u.a.calls, b: u.b.calls }),
+          pair(u.a.failures, u.b.failures, String),
+          pair(u.a.seconds, u.b.seconds, formatSeconds),
+        ]),
+    ),
+  );
+  if (changed.length > MAX_CHANGED_TOOLS) {
+    console.log(`  [... ${changed.length - MAX_CHANGED_TOOLS} more - see --json]`);
   }
 }
 

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -8,6 +8,7 @@ import {
   stepAction,
   stepDiffers,
   stepIndexLabel,
+  type ToolChange,
   type ToolsDiff,
   type TrajectoryStep,
 } from "../../core/compare";
@@ -22,6 +23,7 @@ import { printJson, table } from "../output";
 const MAX_DIFF_LINES = 40;
 const MAX_LINE_CHARS = 160;
 const MAX_NAMES = 8;
+const MAX_CHANGED_TOOLS = 20;
 
 /** Prints metric deltas and config differences between two loaded traces. */
 export function compare(
@@ -184,9 +186,24 @@ function printToolsDiff(tools: ToolsDiff): void {
   if (tools.removed.length > 0) {
     parts.push(`-${tools.removed.length} removed (${names(tools.removed)})`);
   }
-  if (tools.changed.length > 0) {
-    parts.push(`${tools.changed.length} changed (${names(tools.changed)})`);
-  }
+  if (tools.changed.length > 0) parts.push(`${tools.changed.length} changed`);
   parts.push(`${tools.unchanged} unchanged`);
   console.log(`tools          ${parts.join(" · ")}`);
+  if (tools.changed.length === 0) return;
+  console.log("changed tools (definition diffs: --json):");
+  const width = Math.max(...tools.changed.map((change) => change.name.length));
+  for (const change of tools.changed.slice(0, MAX_CHANGED_TOOLS)) {
+    console.log(`  ~ ${change.name.padEnd(width)}  ${changeSummary(change)}`);
+  }
+  if (tools.changed.length > MAX_CHANGED_TOOLS) {
+    console.log(`  [... ${tools.changed.length - MAX_CHANGED_TOOLS} more]`);
+  }
+}
+
+/** "description + schema · +3/-1 lines" style. */
+function changeSummary(change: ToolChange): string {
+  if (change.lines === undefined) return `${change.parts.join(" + ")} · too large to line-diff`;
+  const added = change.lines.filter((line) => line.kind === "added").length;
+  const removed = change.lines.filter((line) => line.kind === "removed").length;
+  return `${change.parts.join(" + ")} · +${added}/-${removed} lines`;
 }

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { collectToolDefs, compareTraces, pairTrajectory } from "./compare";
+import { collectToolDefs, compareTraces, finalText, pairTrajectory, taskPrompt } from "./compare";
 import { diffLines } from "./diff";
 import { normalizeTrace } from "./normalize";
 import type { RawToolDef, RawTrace } from "./types";
@@ -159,6 +159,60 @@ describe("compareTraces", () => {
     expect(change.lines!.some((line) => line.kind === "same" && line.text === "find things")).toBe(
       true,
     );
+  });
+});
+
+describe("compareTraces task and tool usage", () => {
+  it("flags differing tasks and passes identical ones", () => {
+    const same = compareTraces(side(rawTrace({ id: "a" })), side(rawTrace({ id: "b" })));
+    expect(same.task).toEqual({ kind: "identical", chars: 4 });
+
+    const other = rawTrace({ id: "b" });
+    other.events[0]!.messages = [{ role: "user", content: "a different task" }];
+    const diff = compareTraces(side(rawTrace({ id: "a" })), side(other));
+    expect(diff.task.kind).toBe("differs");
+  });
+
+  it("compares per-tool usage, biggest call change first", () => {
+    const withCalls = (id: string, names: string[]) => {
+      const raw = rawTrace({ id, events: names.length });
+      names.forEach((name, i) => {
+        raw.events[i]!.messages.push(
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [{ type: "function", id: `c${i}`, function: { name, arguments: {} } }],
+          },
+          { role: "tool", tool_call_id: `c${i}`, content: "done", duration_ms: 1000 },
+        );
+      });
+      return side(raw);
+    };
+    const comparison = compareTraces(
+      withCalls("a", ["search", "search", "click"]),
+      withCalls("b", ["click"]),
+    );
+    expect(comparison.toolUsage[0]).toMatchObject({
+      name: "search",
+      a: { calls: 2, seconds: 2 },
+      b: { calls: 0, seconds: 0 },
+    });
+    expect(comparison.toolUsage[1]).toMatchObject({
+      name: "click",
+      a: { calls: 1 },
+      b: { calls: 1 },
+    });
+  });
+});
+
+describe("taskPrompt and finalText", () => {
+  it("returns the first user message and the last assistant text", () => {
+    const raw = rawTrace({ id: "a", events: 2 });
+    raw.events[0]!.messages.push({ role: "assistant", content: "working on it" });
+    raw.events[1]!.messages.push({ role: "assistant", content: "all done" });
+    const trace = normalizeTrace(raw);
+    expect(taskPrompt(trace)).toBe("hi 0");
+    expect(finalText(trace)).toBe("all done");
   });
 });
 

--- a/src/core/compare.test.ts
+++ b/src/core/compare.test.ts
@@ -127,12 +127,38 @@ describe("compareTraces", () => {
         rawTrace({ id: "b", tools: [tool("keep", "k"), tool("edit", "new"), tool("add", "a")] }),
       ),
     );
-    expect(comparison.tools).toEqual({
-      added: ["add"],
-      removed: ["drop"],
-      changed: ["edit"],
-      unchanged: 1,
+    expect(comparison.tools).toMatchObject({ added: ["add"], removed: ["drop"], unchanged: 1 });
+    expect(comparison.tools.changed).toEqual([
+      {
+        name: "edit",
+        parts: ["description"],
+        lines: [
+          { kind: "removed", text: "old" },
+          { kind: "added", text: "new" },
+        ],
+      },
+    ]);
+  });
+
+  it("diffs a changed tool schema line by line", () => {
+    const tool = (schema: unknown): RawToolDef => ({
+      type: "function",
+      name: "search",
+      description: "find things",
+      inputSchema: schema,
     });
+    const comparison = compareTraces(
+      side(rawTrace({ id: "a", tools: [tool({ q: "string" })] })),
+      side(rawTrace({ id: "b", tools: [tool({ q: "string", limit: "number" })] })),
+    );
+    const change = comparison.tools.changed[0]!;
+    expect(change.parts).toEqual(["schema"]);
+    expect(change.lines!.some((line) => line.kind === "added" && line.text.includes("limit"))).toBe(
+      true,
+    );
+    expect(change.lines!.some((line) => line.kind === "same" && line.text === "find things")).toBe(
+      true,
+    );
   });
 });
 

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -48,21 +48,87 @@ export interface ToolsDiff {
   unchanged: number;
 }
 
+/** One tool's call activity in both runs. */
+export interface ToolUsageDelta {
+  name: string;
+  a: ToolUsageSide;
+  b: ToolUsageSide;
+}
+
+export interface ToolUsageSide {
+  calls: number;
+  failures: number;
+  seconds: number;
+}
+
 export interface TraceComparison {
   models: { a: string[]; b: string[] };
   metrics: ComparedMetric[];
+  /** The runs' first user messages - differing tasks make deltas misleading. */
+  task: PromptDiff;
   systemPrompt: PromptDiff;
   tools: ToolsDiff;
+  /** Per-tool call activity, biggest call-count change first. */
+  toolUsage: ToolUsageDelta[];
 }
 
-/** Diffs two traces: headline metric deltas plus system prompt and tool-set changes. */
+/** Diffs two traces: headline metric deltas plus task, prompt, and tool changes. */
 export function compareTraces(a: ComparableTrace, b: ComparableTrace): TraceComparison {
   return {
     models: { a: a.trace.models, b: b.trace.models },
     metrics: compareMetrics(a.trace, b.trace),
+    task: comparePrompts(taskPrompt(a.trace), taskPrompt(b.trace)),
     systemPrompt: comparePrompts(systemPrompt(a.trace), systemPrompt(b.trace)),
     tools: compareTools(a.tools, b.tools),
+    toolUsage: compareToolUsage(a.trace, b.trace),
   };
+}
+
+/** The task given to the run: its first user message. */
+export function taskPrompt(trace: NormalizedTrace): string {
+  for (const gen of trace.generations) {
+    for (const message of gen.newMessages) {
+      if (message.role === "user") return message.text;
+    }
+  }
+  return "";
+}
+
+/** What the run concluded: its last assistant message that carries text. */
+export function finalText(trace: NormalizedTrace): string {
+  for (let i = trace.generations.length - 1; i >= 0; i--) {
+    const messages = trace.generations[i]!.newMessages;
+    for (let j = messages.length - 1; j >= 0; j--) {
+      const message = messages[j]!;
+      if (message.role === "assistant" && message.text.trim() !== "") return message.text;
+    }
+  }
+  return "";
+}
+
+function compareToolUsage(a: NormalizedTrace, b: NormalizedTrace): ToolUsageDelta[] {
+  const usage = (trace: NormalizedTrace) => {
+    const byName = new Map<string, ToolUsageSide>();
+    for (const call of allToolCalls(trace)) {
+      const entry = byName.get(call.name) ?? { calls: 0, failures: 0, seconds: 0 };
+      entry.calls++;
+      if (call.success === false) entry.failures++;
+      entry.seconds += (call.durationMs ?? 0) / 1000;
+      byName.set(call.name, entry);
+    }
+    return byName;
+  };
+  const [ua, ub] = [usage(a), usage(b)];
+  const none: ToolUsageSide = { calls: 0, failures: 0, seconds: 0 };
+  const names = [...new Set([...ua.keys(), ...ub.keys()])];
+  return names
+    .map((name) => ({ name, a: ua.get(name) ?? none, b: ub.get(name) ?? none }))
+    .sort(
+      (x, y) =>
+        Math.abs(y.b.calls - y.a.calls) - Math.abs(x.b.calls - x.a.calls) ||
+        y.a.calls + y.b.calls - (x.a.calls + x.b.calls) ||
+        x.name.localeCompare(y.name),
+    );
 }
 
 /** Everything the metric rows read, derived once per side. */

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -32,11 +32,19 @@ export type PromptDiff =
       lines: DiffLine[];
     };
 
+/** One tool whose definition differs between the runs. */
+export interface ToolChange {
+  name: string;
+  /** Which parts of the definition differ. */
+  parts: ("description" | "schema")[];
+  /** Line diff of the rendered definition; absent when too large to diff. */
+  lines?: DiffLine[];
+}
+
 export interface ToolsDiff {
   added: string[];
   removed: string[];
-  /** Same name, different description or input schema. */
-  changed: string[];
+  changed: ToolChange[];
   unchanged: number;
 }
 
@@ -141,7 +149,7 @@ function compareMetrics(a: NormalizedTrace, b: NormalizedTrace): ComparedMetric[
 }
 
 /** The run's system prompt: system messages of the first generation. */
-function systemPrompt(trace: NormalizedTrace): string {
+export function systemPrompt(trace: NormalizedTrace): string {
   return (trace.generations[0]?.newMessages ?? [])
     .filter((message) => message.role === "system")
     .map((message) => message.text)
@@ -177,20 +185,46 @@ function compareTools(defsA: RawToolDef[], defsB: RawToolDef[]): ToolsDiff {
   const b = byName(defsB);
   const added: string[] = [];
   const removed: string[] = [];
-  const changed: string[] = [];
+  const changed: ToolChange[] = [];
   let unchanged = 0;
   for (const name of a.keys()) if (!b.has(name)) removed.push(name);
   for (const [name, def] of b) {
     const other = a.get(name);
-    if (other === undefined) added.push(name);
-    else if (defKey(other) !== defKey(def)) changed.push(name);
+    if (other === undefined) {
+      added.push(name);
+      continue;
+    }
+    const change = toolChange(other, def);
+    if (change !== undefined) changed.push(change);
     else unchanged++;
   }
   return { added, removed, changed, unchanged };
 }
 
-function defKey(def: RawToolDef): string {
-  return JSON.stringify({ description: def.description, inputSchema: def.inputSchema });
+/** What changed in a redefined tool, or undefined when the definitions match. */
+function toolChange(a: RawToolDef, b: RawToolDef): ToolChange | undefined {
+  const parts: ToolChange["parts"] = [];
+  if (a.description !== b.description) parts.push("description");
+  if (JSON.stringify(a.inputSchema) !== JSON.stringify(b.inputSchema)) parts.push("schema");
+  if (parts.length === 0) return undefined;
+  const lines = diffLines(defLines(a), defLines(b));
+  return { name: b.name, parts, ...(lines !== undefined ? { lines } : {}) };
+}
+
+/** The two diffable parts of a tool definition; absent parts render empty. */
+export function toolDefParts(def: RawToolDef): { description: string; schema: string } {
+  return {
+    description: def.description ?? "",
+    schema: def.inputSchema !== undefined ? JSON.stringify(def.inputSchema, null, 2) : "",
+  };
+}
+
+/** A definition as diffable lines: the description text, then the pretty schema. */
+function defLines(def: RawToolDef): string[] {
+  const parts = toolDefParts(def);
+  const lines = parts.description !== "" ? parts.description.split("\n") : [];
+  if (parts.schema !== "") lines.push(...parts.schema.split("\n"));
+  return lines;
 }
 
 export interface TrajectoryStep {

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -4,6 +4,7 @@ import {
   type ComparedMetric,
   collectToolDefs,
   compareTraces,
+  finalText,
   metricDelta,
   metricValue,
   type PromptDiff,
@@ -13,8 +14,10 @@ import {
   stepIndexLabel,
   systemPrompt,
   type ToolChange,
+  type ToolUsageDelta,
   type TraceComparison,
   type TrajectoryStep,
+  taskPrompt,
   toolDefParts,
 } from "@core/compare";
 import { formatSeconds, formatTokens } from "@core/format";
@@ -23,6 +26,8 @@ import { MultiFileDiff } from "@pierre/diffs/react";
 import { useEffect, useMemo, useState } from "react";
 import { MessageCard } from "@/components/MessageCard";
 import { Button } from "@/components/ui/button";
+import { Markdown } from "@/components/ui/markdown";
+import { Section } from "@/components/ui/section";
 import { fetchJson } from "@/lib/api";
 import { localTraceItem } from "@/lib/local-traces";
 import { basename, cn } from "@/lib/utils";
@@ -97,21 +102,36 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
           close
         </Button>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-5 [scrollbar-gutter:stable]">
-        {error && <p className="type-body-s text-ta-error">Failed to compare: {error}</p>}
+      <div className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">
+        {error && <p className="type-body-s p-6 text-ta-error">Failed to compare: {error}</p>}
         {!error && comparison === undefined && (
-          <p className="type-accent-s text-ta-grey-200">loading runs...</p>
+          <p className="type-accent-s p-6 text-ta-grey-200">loading runs...</p>
         )}
         {sides && comparison && steps && (
           <>
             <MetricsGrid comparison={comparison} labels={labels} />
+            <DiffSection
+              title="task"
+              fileName="task.md"
+              diff={comparison.task}
+              a={taskPrompt(sides.a.trace)}
+              b={taskPrompt(sides.b.trace)}
+            />
+            <ToolUsageSection usage={comparison.toolUsage} />
             <Trajectory steps={steps} labels={labels} />
-            <PromptSection
-              prompt={comparison.systemPrompt}
+            <DiffSection
+              title="system prompt"
+              fileName="system-prompt.md"
+              diff={comparison.systemPrompt}
               a={systemPrompt(sides.a.trace)}
               b={systemPrompt(sides.b.trace)}
             />
             <ToolsSection tools={comparison.tools} sides={sides} />
+            <OutcomeSection
+              a={finalText(sides.a.trace)}
+              b={finalText(sides.b.trace)}
+              labels={labels}
+            />
           </>
         )}
       </div>
@@ -174,13 +194,14 @@ function MetricsGrid({ comparison, labels }: { comparison: TraceComparison; labe
   const sameModels = models.a.join(", ") === models.b.join(", ");
   return (
     <Section
-      label={
+      title="totals"
+      meta={
         sameModels
-          ? `totals · ${models.a.join(", ")}`
-          : `totals · ${labels.a}: ${models.a.join(", ")} · ${labels.b}: ${models.b.join(", ")}`
+          ? models.a.join(", ")
+          : `${labels.a}: ${models.a.join(", ")} · ${labels.b}: ${models.b.join(", ")}`
       }
     >
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3 px-6 pb-4">
         {metrics.map((m) => (
           <MetricTile key={m.key} metric={m} labels={labels} />
         ))}
@@ -274,13 +295,15 @@ function Trajectory({ steps, labels }: { steps: TrajectoryStep[]; labels: SideLa
   const different = steps.filter(stepDiffers);
   return (
     <Section
-      label={
+      title="trajectory"
+      meta={
         different.length === 0
-          ? "trajectory · aligned by action · same actions throughout"
-          : `trajectory · aligned by action · differs at ${different.length} of ${steps.length} steps`
+          ? "aligned by action · same actions throughout"
+          : `aligned by action · differs at ${different.length} of ${steps.length} steps`
       }
+      defaultOpen={false}
     >
-      <div className="border border-ta-grey-400">
+      <div className="mx-6 mb-4 border border-ta-grey-400">
         <div
           className={cn(
             ROW_GRID,
@@ -367,24 +390,140 @@ function GenDetail({ gen }: { gen?: Generation }) {
   );
 }
 
-function PromptSection({ prompt, a, b }: { prompt: PromptDiff; a: string; b: string }) {
-  if (prompt.kind === "identical") {
+/** A named text (task, system prompt) diffed A vs B; identical stays collapsed. */
+function DiffSection({
+  title,
+  fileName,
+  diff,
+  a,
+  b,
+}: {
+  title: string;
+  fileName: string;
+  diff: PromptDiff;
+  a: string;
+  b: string;
+}) {
+  if (diff.kind === "identical") {
     return (
-      <Section label="system prompt">
-        <p className="type-body-s text-ta-grey-200">
-          {prompt.chars === 0 ? "none in either run" : `identical (${prompt.chars} chars)`}
+      <Section
+        title={title}
+        meta={diff.chars === 0 ? "none in either run" : `identical (${diff.chars} chars)`}
+        defaultOpen={false}
+      >
+        <p className="type-body-s px-6 pb-4 text-ta-grey-200">
+          {diff.chars === 0 ? "neither run carries one" : "both runs carry the same text"}
         </p>
       </Section>
     );
   }
-  const label =
-    prompt.kind === "differs"
-      ? `system prompt · +${prompt.addedLines} / -${prompt.removedLines} lines`
-      : `system prompt · differs (A ${prompt.aChars} chars, B ${prompt.bChars} chars)`;
   return (
-    <Section label={label}>
-      <TextDiff name="system-prompt.md" before={a} after={b} />
+    <Section
+      title={title}
+      meta={
+        diff.kind === "differs"
+          ? `+${diff.addedLines} / -${diff.removedLines} lines`
+          : `differs (A ${diff.aChars} chars, B ${diff.bChars} chars)`
+      }
+    >
+      <div className="px-6 pb-4">
+        <TextDiff name={fileName} before={a} after={b} />
+      </div>
     </Section>
+  );
+}
+
+const USAGE_GRID =
+  "grid grid-cols-[minmax(9rem,1fr)_4rem_4rem_7rem_6rem_9rem] items-baseline gap-x-4";
+
+/** Per-tool call activity of both runs; rows with identical activity dim. */
+function ToolUsageSection({ usage }: { usage: ToolUsageDelta[] }) {
+  if (usage.length === 0) return null;
+  const changedRows = usage.filter(
+    (u) => u.a.calls !== u.b.calls || u.a.failures !== u.b.failures,
+  ).length;
+  const pair = (a: number, b: number, render: (v: number) => string) =>
+    a === 0 && b === 0 ? "-" : `${render(a)} -> ${render(b)}`;
+  return (
+    <Section
+      title="tool usage"
+      meta={
+        changedRows === 0
+          ? "identical call counts"
+          : `${changedRows} of ${usage.length} tools used differently`
+      }
+      defaultOpen={changedRows > 0}
+    >
+      <div className="type-accent-s px-6 pb-4">
+        <div className={cn(USAGE_GRID, "border-b border-ta-grey-400 pb-1 text-ta-grey-200")}>
+          <span>tool</span>
+          <span className="text-right">A</span>
+          <span className="text-right">B</span>
+          <span className="text-right">delta</span>
+          <span className="text-right">failures</span>
+          <span className="text-right">time</span>
+        </div>
+        {usage.map((u) => {
+          const equal = u.a.calls === u.b.calls && u.a.failures === u.b.failures;
+          return (
+            <div
+              key={u.name}
+              className={cn(
+                USAGE_GRID,
+                "border-b border-ta-grey-450 py-1.5",
+                equal && "opacity-55",
+              )}
+            >
+              <span className="truncate text-ta-sand-50">{u.name}</span>
+              <span className="text-right text-ta-grey-100">{u.a.calls}</span>
+              <span className="text-right text-ta-grey-100">{u.b.calls}</span>
+              <span className={cn("text-right", equal ? "text-ta-grey-300" : "text-ta-orange-300")}>
+                {metricDelta({ key: u.name, kind: "count", a: u.a.calls, b: u.b.calls })}
+              </span>
+              <span
+                className={cn(
+                  "text-right",
+                  u.a.failures + u.b.failures > 0 ? "text-ta-error" : "text-ta-grey-300",
+                )}
+              >
+                {pair(u.a.failures, u.b.failures, String)}
+              </span>
+              <span className="text-right text-ta-grey-200">
+                {pair(u.a.seconds, u.b.seconds, formatSeconds)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Section>
+  );
+}
+
+/** What each run concluded: the final assistant messages side by side. */
+function OutcomeSection({ a, b, labels }: { a: string; b: string; labels: SideLabels }) {
+  if (a === "" && b === "") return null;
+  return (
+    <Section title="outcome" meta="final assistant message of each run">
+      <div className="grid grid-cols-2 gap-3 px-6 pb-4">
+        <OutcomeCard label={`A · ${labels.a}`} text={a} />
+        <OutcomeCard label={`B · ${labels.b}`} text={b} />
+      </div>
+    </Section>
+  );
+}
+
+function OutcomeCard({ label, text }: { label: string; text: string }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2 border border-ta-grey-400 bg-ta-grey-450/40 px-4 py-3">
+      <span className="type-accent-s text-ta-grey-200">{label}</span>
+      {text === "" ? (
+        <p className="type-accent-s text-ta-grey-300">no assistant text in this run</p>
+      ) : (
+        <div className="type-body-s max-h-96 overflow-y-auto">
+          <Markdown>{text}</Markdown>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -408,79 +547,128 @@ function TextDiff({ name, before, after }: { name: string; before: string; after
   );
 }
 
+/** One row of the tool-set diff: an added, removed, or changed tool. */
+interface ToolRow {
+  sign: "+" | "-" | "~";
+  signClass: string;
+  name: string;
+  summary: string;
+  parts: ToolChange["parts"];
+  a?: RawToolDef;
+  b?: RawToolDef;
+}
+
 function ToolsSection({ tools, sides }: { tools: TraceComparison["tools"]; sides: Sides }) {
   const [expanded, setExpanded] = useState<string>();
   const total = tools.unchanged + tools.changed.length + tools.added.length + tools.removed.length;
-  const defs = useMemo(
-    () => ({
-      a: new Map(sides.a.tools.map((def) => [def.name, def])),
-      b: new Map(sides.b.tools.map((def) => [def.name, def])),
-    }),
-    [sides],
-  );
+  const rows = useMemo(() => toolRows(tools, sides), [tools, sides]);
+  const counts = [
+    ...(tools.added.length > 0 ? [`+${tools.added.length} added`] : []),
+    ...(tools.removed.length > 0 ? [`-${tools.removed.length} removed`] : []),
+    ...(tools.changed.length > 0 ? [`~${tools.changed.length} changed`] : []),
+    `${tools.unchanged} unchanged`,
+  ];
   return (
-    <Section label={`tools · ${tools.unchanged} unchanged`}>
-      {total === 0 ? (
-        <p className="type-body-s text-ta-grey-200">none in either run</p>
-      ) : (
-        <div className="type-body-s flex flex-col gap-1">
-          {tools.added.length > 0 && (
-            <p className="text-ta-orange-75">+ added: {tools.added.join(", ")}</p>
-          )}
-          {tools.removed.length > 0 && (
-            <p className="text-ta-error">- removed: {tools.removed.join(", ")}</p>
-          )}
-          {tools.changed.length > 0 && (
-            <div className="mt-1 border border-ta-grey-400">
-              {tools.changed.map((change) => (
-                <div key={change.name} className="border-b border-ta-grey-400 last:border-b-0">
-                  <button
-                    type="button"
-                    onClick={() => setExpanded(expanded === change.name ? undefined : change.name)}
-                    aria-expanded={expanded === change.name}
-                    className={cn(
-                      "flex w-full cursor-pointer items-baseline gap-3 px-4 py-2 text-left transition-colors hover:bg-ta-grey-450",
-                      expanded === change.name && "bg-ta-grey-450",
-                    )}
-                  >
-                    <span className="text-ta-sand-50">~ {change.name}</span>
-                    <span className="text-ta-grey-300">{changeSummary(change)}</span>
-                  </button>
-                  {expanded === change.name && (
-                    <ToolChangeDetail
-                      change={change}
-                      a={defs.a.get(change.name)!}
-                      b={defs.b.get(change.name)!}
-                    />
+    <Section title="tools" meta={counts.join(" · ")} defaultOpen={rows.length > 0}>
+      <div className="px-6 pb-4">
+        {total === 0 ? (
+          <p className="type-body-s text-ta-grey-200">none in either run</p>
+        ) : rows.length === 0 ? (
+          <p className="type-body-s text-ta-grey-200">identical tool set</p>
+        ) : (
+          <div className="type-body-s border border-ta-grey-400">
+            {rows.map((row) => (
+              <div key={row.name} className="border-b border-ta-grey-400 last:border-b-0">
+                <button
+                  type="button"
+                  onClick={() => setExpanded(expanded === row.name ? undefined : row.name)}
+                  aria-expanded={expanded === row.name}
+                  className={cn(
+                    "flex w-full cursor-pointer items-baseline gap-3 px-4 py-2 text-left transition-colors hover:bg-ta-grey-450",
+                    expanded === row.name && "bg-ta-grey-450",
                   )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+                >
+                  <span className={row.signClass}>
+                    {row.sign} {row.name}
+                  </span>
+                  <span className="text-ta-grey-300">{row.summary}</span>
+                </button>
+                {expanded === row.name && <ToolDefDiff row={row} />}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </Section>
   );
 }
 
-/** The changed parts of one redefined tool, each as its own before/after diff. */
-function ToolChangeDetail({ change, a, b }: { change: ToolChange; a: RawToolDef; b: RawToolDef }) {
-  const [partsA, partsB] = [toolDefParts(a), toolDefParts(b)];
+/** Added, removed, then changed tools, each with what to show when expanded. */
+function toolRows(tools: TraceComparison["tools"], sides: Sides): ToolRow[] {
+  const defs = {
+    a: new Map(sides.a.tools.map((def) => [def.name, def])),
+    b: new Map(sides.b.tools.map((def) => [def.name, def])),
+  };
+  const presentParts = (def: RawToolDef | undefined): ToolChange["parts"] => {
+    if (def === undefined) return [];
+    const parts = toolDefParts(def);
+    return [
+      ...(parts.description !== "" ? (["description"] as const) : []),
+      ...(parts.schema !== "" ? (["schema"] as const) : []),
+    ];
+  };
+  return [
+    ...tools.added.map((name): ToolRow => {
+      const b = defs.b.get(name);
+      return {
+        sign: "+",
+        signClass: "text-ta-orange-75",
+        name,
+        summary: "only in B",
+        parts: presentParts(b),
+        ...(b !== undefined ? { b } : {}),
+      };
+    }),
+    ...tools.removed.map((name): ToolRow => {
+      const a = defs.a.get(name);
+      return {
+        sign: "-",
+        signClass: "text-ta-error",
+        name,
+        summary: "only in A",
+        parts: presentParts(a),
+        ...(a !== undefined ? { a } : {}),
+      };
+    }),
+    ...tools.changed.map(
+      (change): ToolRow => ({
+        sign: "~",
+        signClass: "text-ta-sand-50",
+        name: change.name,
+        summary: changeSummary(change),
+        parts: change.parts,
+        ...(defs.a.has(change.name) ? { a: defs.a.get(change.name) } : {}),
+        ...(defs.b.has(change.name) ? { b: defs.b.get(change.name) } : {}),
+      }),
+    ),
+  ];
+}
+
+/**
+ * A tool's definition parts, each as its own before/after diff. Added and
+ * removed tools diff against nothing, rendering as all-new or all-gone.
+ */
+function ToolDefDiff({ row }: { row: ToolRow }) {
+  const empty = { description: "", schema: "" };
+  const partsA = row.a !== undefined ? toolDefParts(row.a) : empty;
+  const partsB = row.b !== undefined ? toolDefParts(row.b) : empty;
   return (
     <div className="flex flex-col gap-3 border-t border-ta-grey-400 px-4 py-3">
-      {change.parts.includes("description") && (
-        <TextDiff
-          name={`${change.name}.md`}
-          before={partsA.description}
-          after={partsB.description}
-        />
+      {row.parts.includes("description") && (
+        <TextDiff name={`${row.name}.md`} before={partsA.description} after={partsB.description} />
       )}
-      {change.parts.includes("schema") && (
-        <TextDiff
-          name={`${change.name}.schema.json`}
-          before={partsA.schema}
-          after={partsB.schema}
-        />
+      {row.parts.includes("schema") && (
+        <TextDiff name={`${row.name}.schema.json`} before={partsA.schema} after={partsB.schema} />
       )}
     </div>
   );
@@ -492,15 +680,6 @@ function changeSummary(change: ToolChange): string {
   const added = change.lines.filter((line) => line.kind === "added").length;
   const removed = change.lines.filter((line) => line.kind === "removed").length;
   return `${change.parts.join(" + ")} · +${added}/-${removed} lines`;
-}
-
-function Section({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-2">
-      <p className="type-accent-s text-ta-grey-200">{label}</p>
-      {children}
-    </div>
-  );
 }
 
 /** A run's comparable form, from local memory for browser-opened files, else the server. */

--- a/src/viewer/components/CompareView.tsx
+++ b/src/viewer/components/CompareView.tsx
@@ -11,11 +11,15 @@ import {
   stepAction,
   stepDiffers,
   stepIndexLabel,
+  systemPrompt,
+  type ToolChange,
   type TraceComparison,
   type TrajectoryStep,
+  toolDefParts,
 } from "@core/compare";
 import { formatSeconds, formatTokens } from "@core/format";
 import type { Generation, NormalizedTrace, RawToolDef } from "@core/types";
+import { MultiFileDiff } from "@pierre/diffs/react";
 import { useEffect, useMemo, useState } from "react";
 import { MessageCard } from "@/components/MessageCard";
 import { Button } from "@/components/ui/button";
@@ -30,6 +34,11 @@ interface CompareViewProps {
   onClose: () => void;
 }
 
+interface Sides {
+  a: ComparableTrace;
+  b: ComparableTrace;
+}
+
 /**
  * Full-pane A/B exploration: aligned per-generation trajectory with
  * expandable message detail, headline deltas, prompt and tool diffs.
@@ -39,7 +48,7 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
   const [bId, setBId] = useState(
     () => (runs.find((run) => run.id !== initialA) ?? runs[0])?.id ?? initialA,
   );
-  const [sides, setSides] = useState<{ a: ComparableTrace; b: ComparableTrace }>();
+  const [sides, setSides] = useState<Sides>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
@@ -93,12 +102,16 @@ export function CompareView({ runs, initialA, onClose }: CompareViewProps) {
         {!error && comparison === undefined && (
           <p className="type-accent-s text-ta-grey-200">loading runs...</p>
         )}
-        {comparison && steps && (
+        {sides && comparison && steps && (
           <>
             <MetricsGrid comparison={comparison} labels={labels} />
             <Trajectory steps={steps} labels={labels} />
-            <PromptSection prompt={comparison.systemPrompt} />
-            <ToolsSection tools={comparison.tools} />
+            <PromptSection
+              prompt={comparison.systemPrompt}
+              a={systemPrompt(sides.a.trace)}
+              b={systemPrompt(sides.b.trace)}
+            />
+            <ToolsSection tools={comparison.tools} sides={sides} />
           </>
         )}
       </div>
@@ -354,10 +367,7 @@ function GenDetail({ gen }: { gen?: Generation }) {
   );
 }
 
-/** Full diff is rendered; the pane scrolls. */
-const MAX_RENDERED_DIFF_LINES = 600;
-
-function PromptSection({ prompt }: { prompt: PromptDiff }) {
+function PromptSection({ prompt, a, b }: { prompt: PromptDiff; a: string; b: string }) {
   if (prompt.kind === "identical") {
     return (
       <Section label="system prompt">
@@ -367,48 +377,49 @@ function PromptSection({ prompt }: { prompt: PromptDiff }) {
       </Section>
     );
   }
-  if (prompt.kind === "too-large") {
-    return (
-      <Section label="system prompt">
-        <p className="type-body-s text-ta-grey-200">
-          differs (A {prompt.aChars} chars, B {prompt.bChars} chars - too large to line-diff)
-        </p>
-      </Section>
-    );
-  }
-  const lines = prompt.lines.slice(0, MAX_RENDERED_DIFF_LINES);
+  const label =
+    prompt.kind === "differs"
+      ? `system prompt · +${prompt.addedLines} / -${prompt.removedLines} lines`
+      : `system prompt · differs (A ${prompt.aChars} chars, B ${prompt.bChars} chars)`;
   return (
-    <Section label={`system prompt · +${prompt.addedLines} / -${prompt.removedLines} lines`}>
-      <div className="type-body-s overflow-x-auto whitespace-pre border border-ta-grey-400 bg-ta-grey-450 px-3 py-2 font-(family-name:--font-dm-mono) leading-relaxed">
-        {lines.map((line, i) => (
-          <div
-            // diff lines have no identity beyond their position
-            // biome-ignore lint/suspicious/noArrayIndexKey: positional list
-            key={i}
-            className={cn(
-              line.kind === "added" && "bg-ta-orange-300/10 text-ta-orange-75",
-              line.kind === "removed" && "bg-ta-error/10 text-ta-error",
-              line.kind === "same" && "text-ta-grey-200",
-            )}
-          >
-            {line.kind === "added" ? "+ " : line.kind === "removed" ? "- " : "  "}
-            {line.text}
-          </div>
-        ))}
-        {prompt.lines.length > lines.length && (
-          <div className="text-ta-grey-300">
-            [... {prompt.lines.length - lines.length} more lines]
-          </div>
-        )}
-      </div>
+    <Section label={label}>
+      <TextDiff name="system-prompt.md" before={a} after={b} />
     </Section>
   );
 }
 
-function ToolsSection({ tools }: { tools: TraceComparison["tools"] }) {
-  const total = tools.unchanged + tools.changed.length + tools.added.length + tools.removed.length;
+/** Shared @pierre/diffs settings; unchanged stretches collapse behind expanders. */
+const DIFF_OPTIONS = {
+  theme: "pierre-dark",
+  themeType: "dark",
+  diffStyle: "split",
+  disableFileHeader: true,
+  overflow: "wrap",
+} as const;
+
+/** A split before/after diff of two texts; `name`'s extension picks the highlighting. */
+function TextDiff({ name, before, after }: { name: string; before: string; after: string }) {
+  const oldFile = useMemo(() => ({ name, contents: before }), [name, before]);
+  const newFile = useMemo(() => ({ name, contents: after }), [name, after]);
   return (
-    <Section label="tools">
+    <div className="overflow-hidden border border-ta-grey-400">
+      <MultiFileDiff oldFile={oldFile} newFile={newFile} options={DIFF_OPTIONS} />
+    </div>
+  );
+}
+
+function ToolsSection({ tools, sides }: { tools: TraceComparison["tools"]; sides: Sides }) {
+  const [expanded, setExpanded] = useState<string>();
+  const total = tools.unchanged + tools.changed.length + tools.added.length + tools.removed.length;
+  const defs = useMemo(
+    () => ({
+      a: new Map(sides.a.tools.map((def) => [def.name, def])),
+      b: new Map(sides.b.tools.map((def) => [def.name, def])),
+    }),
+    [sides],
+  );
+  return (
+    <Section label={`tools · ${tools.unchanged} unchanged`}>
       {total === 0 ? (
         <p className="type-body-s text-ta-grey-200">none in either run</p>
       ) : (
@@ -420,13 +431,67 @@ function ToolsSection({ tools }: { tools: TraceComparison["tools"] }) {
             <p className="text-ta-error">- removed: {tools.removed.join(", ")}</p>
           )}
           {tools.changed.length > 0 && (
-            <p className="text-ta-sand-50">changed: {tools.changed.join(", ")}</p>
+            <div className="mt-1 border border-ta-grey-400">
+              {tools.changed.map((change) => (
+                <div key={change.name} className="border-b border-ta-grey-400 last:border-b-0">
+                  <button
+                    type="button"
+                    onClick={() => setExpanded(expanded === change.name ? undefined : change.name)}
+                    aria-expanded={expanded === change.name}
+                    className={cn(
+                      "flex w-full cursor-pointer items-baseline gap-3 px-4 py-2 text-left transition-colors hover:bg-ta-grey-450",
+                      expanded === change.name && "bg-ta-grey-450",
+                    )}
+                  >
+                    <span className="text-ta-sand-50">~ {change.name}</span>
+                    <span className="text-ta-grey-300">{changeSummary(change)}</span>
+                  </button>
+                  {expanded === change.name && (
+                    <ToolChangeDetail
+                      change={change}
+                      a={defs.a.get(change.name)!}
+                      b={defs.b.get(change.name)!}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
           )}
-          <p className="text-ta-grey-200">{tools.unchanged} unchanged</p>
         </div>
       )}
     </Section>
   );
+}
+
+/** The changed parts of one redefined tool, each as its own before/after diff. */
+function ToolChangeDetail({ change, a, b }: { change: ToolChange; a: RawToolDef; b: RawToolDef }) {
+  const [partsA, partsB] = [toolDefParts(a), toolDefParts(b)];
+  return (
+    <div className="flex flex-col gap-3 border-t border-ta-grey-400 px-4 py-3">
+      {change.parts.includes("description") && (
+        <TextDiff
+          name={`${change.name}.md`}
+          before={partsA.description}
+          after={partsB.description}
+        />
+      )}
+      {change.parts.includes("schema") && (
+        <TextDiff
+          name={`${change.name}.schema.json`}
+          before={partsA.schema}
+          after={partsB.schema}
+        />
+      )}
+    </div>
+  );
+}
+
+/** "description + schema · +3/-1 lines" style. */
+function changeSummary(change: ToolChange): string {
+  if (change.lines === undefined) return change.parts.join(" + ");
+  const added = change.lines.filter((line) => line.kind === "added").length;
+  const removed = change.lines.filter((line) => line.kind === "removed").length;
+  return `${change.parts.join(" + ")} · +${added}/-${removed} lines`;
 }
 
 function Section({ label, children }: { label: string; children: React.ReactNode }) {

--- a/src/viewer/lib/shiki-slim.ts
+++ b/src/viewer/lib/shiki-slim.ts
@@ -1,0 +1,28 @@
+import { createBundledHighlighter, createSingletonShorthands } from "@shikijs/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+export * from "@shikijs/core";
+export { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+export { createOnigurumaEngine } from "shiki/engine/oniguruma";
+
+/**
+ * Stands in for the full `shiki` bundle at build time (vite alias). The full
+ * bundle ships every grammar as its own chunk (~10MB of dist); the compare
+ * view only diffs prose and schemas, so only these grammars ship. Anything
+ * else falls back to unhighlighted text.
+ */
+export const bundledLanguages = {
+  markdown: () => import("@shikijs/langs/markdown"),
+  json: () => import("@shikijs/langs/json"),
+};
+
+export const bundledThemes = {};
+
+export const createHighlighter = createBundledHighlighter({
+  langs: bundledLanguages,
+  themes: bundledThemes,
+  engine: () => createJavaScriptRegexEngine(),
+});
+
+export const { codeToHtml, codeToHast, codeToTokens, getSingletonHighlighter } =
+  createSingletonShorthands(createHighlighter);

--- a/src/viewer/lib/shiki-wasm-stub.ts
+++ b/src/viewer/lib/shiki-wasm-stub.ts
@@ -1,0 +1,6 @@
+/**
+ * Stands in for `shiki/wasm` at build time (vite alias). The viewer pins the
+ * JavaScript regex engine, so the oniguruma wasm binary never loads - this
+ * keeps its ~600KB chunk out of dist.
+ */
+export default {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,10 +71,20 @@ export default defineConfig({
   root: "src/viewer",
   plugins: [react(), tailwindcss(), devTraceApi()],
   resolve: {
-    alias: {
-      "@": resolve(import.meta.dirname, "src/viewer"),
-      "@core": resolve(import.meta.dirname, "src/core"),
-    },
+    alias: [
+      { find: "@core", replacement: resolve(import.meta.dirname, "src/core") },
+      { find: "@", replacement: resolve(import.meta.dirname, "src/viewer") },
+      // @pierre/diffs imports the full shiki bundle (every grammar as a
+      // chunk); the viewer only diffs markdown and json - see the shims
+      {
+        find: /^shiki$/,
+        replacement: resolve(import.meta.dirname, "src/viewer/lib/shiki-slim.ts"),
+      },
+      {
+        find: /^shiki\/wasm$/,
+        replacement: resolve(import.meta.dirname, "src/viewer/lib/shiki-wasm-stub.ts"),
+      },
+    ],
   },
   build: {
     outDir: resolve(import.meta.dirname, "dist/viewer"),


### PR DESCRIPTION
# Overview

The tools diff previously printed a flat `changed: <16 names>` and the compare pane was one long wall. This PR makes the comparison actually explain itself:

**More signal from the pair of traces**
- **Task diff**: the runs' first user messages, diffed. Differing tasks make every other delta misleading - now it's the second thing you see (the demo traces turned out to be a 7-step vs 5-step test; the task diff catches it instantly).
- **Per-tool usage deltas**: calls / failures / time per tool across both runs, biggest change first (CLI table + viewer section, identical rows dimmed).
- **Outcome**: each run's final assistant message side by side in the viewer.
- **Per-tool definition diffs**: `ToolsDiff.changed` carries which parts differ (description/schema) plus the definition line diff; CLI prints `~ ui_click  description + schema · +1/-14 lines`, `--json` has it all.

**Viewer structure**
- Compare sections use the canonical collapsible `Section` from the main page (chevron, meta in the header). Trajectory is collapsed by default with its summary in the header.
- The tool-set diff is one unified expandable list: `+ added` / `- removed` rows expand to the full definition (all-green / all-red), `~ changed` rows expand to per-part split diffs.
- Prompt / task / tool diffs render via [@pierre/diffs](https://diffs.com): split view, word-level inline highlights, collapsed unchanged context, markdown/JSON highlighting. Also removes the viewer's too-large-to-diff limitation.

**Bundle**: @pierre/diffs pulls shiki's full bundle (dist ballooned to 12M). A vite alias swaps `shiki` for a slim shim with only markdown+json grammars and stubs `shiki/wasm`: dist is 3.0M; remaining theme chunks are lazy and never load.

## Test plan

- [x] `npm run check` passes (53 tests: change parts, schema diffs, task diff, tool usage ordering, taskPrompt/finalText, tool-def dedupe, /api/tools)
- [x] CLI on real traces: task diff caught differing tasks; usage table surfaces +38 ui_click / +36 start_step; `--json` spot-checked (removed `settle` param visible per tool)
- [x] Viewer verified in a real browser: section chevrons work, trajectory collapsed by default, added tool expands to full highlighted definition, changed tool shows split JSON diff, outcome cards render
- [x] Built from `dist`, bundle 12M -> 3.0M after the shiki shim